### PR TITLE
add missing parenthesis to ldap filter

### DIFF
--- a/login.php
+++ b/login.php
@@ -42,7 +42,7 @@
 
 	  $sanitizedUsername = ldap_escape($username, "", LDAP_ESCAPE_FILTER);
 
-	  $filter = "(|(uid=$sanitizedUsername)(mail=$sanitizedUsername)";
+	  $filter = "(|(uid=$sanitizedUsername)(mail=$sanitizedUsername))";
 
 	  if (($result = ldap_search($connection, $search_dn, $filter)) == false) {
 		print "Fehler: Suche im LDAP-Baum fehlgeschlagen<br>";


### PR DESCRIPTION
We had to add a parenthesis to the ldap search filter to work wirh LDAP. Seems to be a bug .