### PR TITLE
bugfix: ob_flush causes error message

### DIFF
--- a/stream-api.php
+++ b/stream-api.php
@@ -41,7 +41,7 @@ curl_setopt($ch, CURLOPT_HTTPHEADER, [
 ]);
 curl_setopt($ch, CURLOPT_WRITEFUNCTION, function($ch, $data) {
 	echo $data;
-	ob_flush();
+	// ob_flush();
 	flush();
 	return strlen($data);
 });


### PR DESCRIPTION
Docker environment with PHP 8.2.9 and Apache 2.4.57: 
When reading response from ChatGPT an error occurs on calling ob_flush because there is nothing to be flushed. 
As a result there is no output visible from ChatGPT...
Maybe there is a better solution for this than just commenting out the function.