### PR TITLE
Ldap bind as user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,8 @@
 Authentication="LDAP"
 ; LDAP config
 LDAP_HOST="ldaps://..."
-LDAP_BASE_DN="cn=...,ou=...,dc=..."
-LDAP_BIND_PW="..."
-LDAP_SEARCH_DN="ou=...,dc=..."
+LDAP_PATTERN="uid=%username%,ou=people,dc=example,dc=com"
+LDAP_FILTER="(objectClass=*)"
 
 ; Open Ai config
 OPENAI_API_KEY="sk-..."

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 .DS_Store
+.idea
 
 feedback/*/***

--- a/README.md
+++ b/README.md
@@ -51,22 +51,21 @@ To generate answers HAWKI uses the Open AI api. Follow the instructions on https
 
 To get started you need to add a configuration file to the project first. Copy the file ".env.example" from the root directory and rename it to ".env". Replace the example values in it with your own configuration. A detailed description of all values is listed below.
 
-| Value            | Type    | Example                                | Description                                                                                                                                        |
-| ---------------- | ------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Authentication   | string  | 'LDAP' or 'OIDC'                        | Authentication method: LDAP or OpenID Connect                                                                                                      |
-| LDAP_HOST        | string  | "ldaps://...de"                        | The URL of your LDAP server.                                                                                                                       |
-| LDAP_BIND_PW     | string  | secretpassword                         | Password of the user that is trying to bind to the LDAP Server.                                                                                    |
-| LDAP_BASE_DN     | string  | "cn=...,ou=...,dc=..."                 | Distinguised name that is used to initially bind to your LDAP server.                                                                              |
-| LDAP_SEARCH_DN   | string  | "ou=...,dc=..."                        | Distinguished name that is used for authenticating users.                                                                                          |
-| OIDC_IDP          | string  | "https://...."                         | URL of the Identity provider supporting OpenID Connect.                                                                                            |
-| OIDC_CLIENT_ID    | string  | "..."                                  | Client Id for this application in Identity provider.                                                                                               |
-| OIDC_CLIENT_SECRET | string  | "..."                                 | Secret key for OpenID Connect. 
-| OIDC_LOGOUT_URI | string  | "https://...."                                 | URL to logout from Identity provider                                                                                                                  |
-| OPENAI_API_KEY   | string  | sk-...                                 | Open AI Api key                                                                                                                                    |
-| IMPRINT_LOCATION | string  | https://your-university/imprint        | A link to your imprint. Alternatively you can replace the file index.php under /impressum with your own html/ php of your imprint.                 |
-| PRIVACY_LOCATION | string  | https://your-university/privacy-policy | A link to your privacy policy. Alternatively you can replace the file index.php under /datenschutz with your own html/ php of your privacy policy. |
-| TESTUSER         | boolean | `false`                                | Can be set to `true` for testing purposes. You can then sign in using username `tester` and password `superlangespasswort123`                      |
-| FAVICON_URI  | string  | "https://...."                                 | Link to favicon 
+| Value            | Type    | Example                                      | Description                                                                                                                                        |
+| ---------------- | ------- |----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Authentication   | string  | 'LDAP' or 'OIDC'                             | Authentication method: LDAP or OpenID Connect                                                                                                      |
+| LDAP_HOST        | string  | "ldaps://...de"                              | The URL of your LDAP server.                                                                                                                       |
+| LDAP_PATTERN     | string  | "uid=%username%,ou=people,dc=example,dc=com" | DN Pattern of the user entries (%username% is replaced by the login username).                                                                     |
+| LDAP_FILTER     | string  | "(objectClass=*)"                            | Additional filter to apply to the user entry to limit access to users with certain attributes.                                                     |
+| OIDC_IDP          | string  | "https://...."                               | URL of the Identity provider supporting OpenID Connect.                                                                                            |
+| OIDC_CLIENT_ID    | string  | "..."                                        | Client Id for this application in Identity provider.                                                                                               |
+| OIDC_CLIENT_SECRET | string  | "..."                                        | Secret key for OpenID Connect.                                                                                                                     
+| OIDC_LOGOUT_URI | string  | "https://...."                               | URL to logout from Identity provider                                                                                                               |
+| OPENAI_API_KEY   | string  | sk-...                                       | Open AI Api key                                                                                                                                    |
+| IMPRINT_LOCATION | string  | https://your-university/imprint              | A link to your imprint. Alternatively you can replace the file index.php under /impressum with your own html/ php of your imprint.                 |
+| PRIVACY_LOCATION | string  | https://your-university/privacy-policy       | A link to your privacy policy. Alternatively you can replace the file index.php under /datenschutz with your own html/ php of your privacy policy. |
+| TESTUSER         | boolean | `false`                                      | Can be set to `true` for testing purposes. You can then sign in using username `tester` and password `superlangespasswort123`                      |
+| FAVICON_URI  | string  | "https://...."                               | Link to favicon                                                                                                                                    
 
 ## Web Server Configuration
 


### PR DESCRIPTION
LDAP authentication with a dedicated user for the application itself seems needlessly complicated.
The downside of this approach is that it requires the LDAP admin to create a user for HAWKI on the LDAP side and give it read access to all user entries - which is also a security concern.

With this pull request I propose to use a bind-as-user approach that usually does not need any actions on the LDAP side.
All that is needed is that users are allowed to read their own entry - which is usually allowed by default.