### PR TITLE
detect code blocks again

### DIFF
--- a/interface.php
+++ b/interface.php
@@ -417,6 +417,7 @@ if (!isset($_SESSION['username'])) {
 				let innerHTML = document.querySelector(".message:last-child").querySelector(".message-text").innerHTML
 				// innerHTML = innerHTML.replace(/```([\s\S]+?)```/g, '<pre><code>$1</code></pre>').replace(/\*\*.*?\*\*/g, '');
 				innerHTML = innerHTML.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+				innerHTML = innerHTML.replace(/```([\s\S]+?)```/g, '<pre><code>$1</code></pre>');
 				messageTextElement.innerHTML = innerHTML;
 
 				hljs.highlightAll();


### PR DESCRIPTION
It looks like you accidentally removed the code block detection while fixing https://github.com/HAWK-Digital-Environments/HAWKI/issues/24, so I added it again as separate line.