### PR TITLE
Option zum serverseitigen Festlegen des GPT-Models hinzugefuegt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ OIDC_LOGOUT=""
 
 ;Favicon
 FAVICON_URI=""
+
+;GPT model to be used
+GPT_MODEL="gpt-4-turbo-preview"
+;whether or not to force usage of the predetermined GPT model
+FORCE_MODEL=true

--- a/stream-api.php
+++ b/stream-api.php
@@ -29,6 +29,11 @@ $apiKey = isset($env) ? $env['OPENAI_API_KEY'] : getenv('OPENAI_API_KEY');
 
 // Read the request payload from the client
 $requestPayload = file_get_contents('php://input');
+if (true == $env['FORCE_MODEL']) {
+	$r = json_decode($requestPayload, true);
+	$r['model'] = $env['GPT_MODEL'];
+	$requestPayload  = json_encode($r);
+}
 
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_URL, $apiUrl);


### PR DESCRIPTION
Bisher wird das verwendete GPT-Modell lediglich auf der Clientseite in einem durch den Nutzer veränderbaren Feld festgelegt. Dieser Patch führt eine Option ein, dass immer ein bestimmtes Modell verwendet wird. Dieses Modell wird dann auf Serverseite eingefügt, bevor der Stream an ChatGPT weitergeschickt wird.