### PR TITLE
Fix "headers already sent"

### DIFF
--- a/interface.php
+++ b/interface.php
@@ -1,10 +1,3 @@
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/vs.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
-
-<!-- and it's easy to individually load additional languages -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/go.min.js"></script>
-
 <?php
 	session_start();
 	if (!isset($_SESSION['username'])) {
@@ -12,6 +5,13 @@
 		exit;
 	}
 ?>
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/vs.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
+
+<!-- and it's easy to individually load additional languages -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/go.min.js"></script>
 
 <link rel="stylesheet" href="app.css">	
 


### PR DESCRIPTION
`interface.php` sends HTML before trying to establish a session and trying to forward the user to the login page. If the user is not logged in, this results in the following error:

```
PHP Warning:  session_start(): Session cannot be started after headers have already been sent in /var/www/interface.php on line 9
PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/interface.php:1) in /var/www/interface.php on line 11
```

This pull request moves the PHP code before any HTML output and fixes this bug.