### PR TITLE
configurable languages

### DIFF
--- a/private/.env.example
+++ b/private/.env.example
@@ -49,3 +49,4 @@ FAVICON_URI=""
 
 # Default Language, leave blank to use default language of the user's browser.
 DEFAULT_LANGUAGE="de_DE"
+ACTIVE_LANGUAGES="de_DE en_US es_ES fr_FR it_IT"

--- a/private/app/php/language_controller.php
+++ b/private/app/php/language_controller.php
@@ -5,6 +5,23 @@
     require_once BOOTSTRAP_PATH;
     require_once  LIBRARY_PATH . 'csrf.php';
     
+    function activeLanguages() {
+
+        if (file_exists(ENV_FILE_PATH)) {
+            $env = parse_ini_file(ENV_FILE_PATH);
+        }
+
+        $activeLanguages = isset($env) ? $env['ACTIVE_LANGUAGES'] : getenv('ACTIVE_LANGUAGES');
+        $activeLanguages = explode(' ', $activeLanguages);
+
+        if ( !count( $activeLanguages ) ) {
+             // default if no active languages are set
+            return ['de_DE', 'en_US', 'es_ES', 'fr_FR', 'it_IT'];
+        }
+
+        return $activeLanguages;
+    }
+
     function setLanguage(){
         //LANGUAGE CHANGE...
         if(isset($_SESSION['language'])){
@@ -22,7 +39,7 @@
             }
             else{
                 //hard code to german
-                $languages = ['de_DE', 'en_US', 'es_ES', 'fr_FR', 'it_IT'];
+                $languages = activeLanguages();
                 $acceptLang = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
                 $matchingLang = substr($acceptLang, 0, 2);
                 foreach ($languages as $lang) {
@@ -44,8 +61,6 @@
         $_SESSION['translation'] = $translation;
     }
 
-
-
     // Check if the request is POST
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // CSRF Protection
@@ -60,7 +75,7 @@
         }
 
         // Check if the requested language is valid
-        $languages = ['de_DE', 'en_US', 'es_ES', 'fr_FR', 'it_IT'];
+        $languages = activeLanguages();
 
         $jsonString = file_get_contents("php://input");
 

--- a/private/views/settings.php
+++ b/private/views/settings.php
@@ -28,21 +28,13 @@
                 <div class="settings-section">
                     <h3><?php echo $translation["language"]; ?></h3>
                     <div class="language-selection">
-                        <a class="language-btn" onclick="changeLanguage('de_DE')" id="de_DE_btn">
-                            DE
-                        </a>
-                        <a class="language-btn" onclick="changeLanguage('en_US')" id="en_US_btn">
-                            EN
-                        </a>
-                        <a class="language-btn" onclick="changeLanguage('es_ES')" id="es_ES_btn">
-                            ES
-                        </a>
-                        <a class="language-btn" onclick="changeLanguage('fr_FR')" id="fr_FR_btn">
-                            FR
-                        </a>
-                        <a class="language-btn" onclick="changeLanguage('it_IT')" id="it_IT_btn">
-                            IT
-                        </a>
+                        <?php
+                        $languages = activeLanguages();
+                        foreach ($languages as $lang) {
+                            $langShort = strtoupper( explode('_', $lang)[0] );
+                            echo '<a class="language-btn" onclick="changeLanguage(\'' . $lang . '\')" id="' . $lang . '_btn">' . $langShort . '</a>';
+                        }
+                        ?>
                     </div>
                 </div>
                 


### PR DESCRIPTION
the layout and language files are not yet university-independent.

unfortunately we do not have the time to adapt all languages. therefore we have decided on a subset and have made this configurable in the .env.

this also has the advantage that settings.php no longer contains any magic/redundant knowledge about the supported languages.


since php is not really my everyday language, it would be especially good to check if the following check is correct at this point:
if ( !count( $activeLanguages ) ) {