### PR TITLE
Add option for LDAP default username initials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To get started you need to add a configuration file to the project first. Copy t
 | LDAP_SEARCH_DN   | string  | "ou=...,dc=..."                        | Distinguished name that is used for authenticating users.                                                                                          |
 | LDAP_PORT  | string  | "..."                        | The LDAP port.                                                                                          |
 | LDAP_FILTER  | string  | "..."  | LDAP Filter. Choose the filter based on your LDAP configuration. See .env.example for more details.|
+| LDAP_DEFAULT_INITIALS  | string  | "ABC"  | User initials to use for every user. If not set, try to compute initials from LDAP displayname.|
 | SHIBBOLET_LOGIN_PATH    | string  | "..."                                  | Path to shibboleth login page.                                                                                               |
 | SHIBBOLET_LOGIN_PAGE    | string  | "..."                                  | Shibboleth login page.                                                                                               |
 | OIDC_IDP          | string  | "https://...."                         | URL of the Identity provider supporting OpenID Connect.                                                                                            |

--- a/private/.env.example
+++ b/private/.env.example
@@ -11,6 +11,7 @@ LDAP_PORT=""
 ; (|(sAMAccountName=username)(mail=username))
 ; (|(uid=username)(mail=username))
 LDAP_FILTER="(|(sAMAccountName=username)(mail=username))"
+; LDAP_DEFAULT_INITIALS="ABC"
 
 #Shibbolet
 SHIBBOLETH_LOGIN_PATH="Shibboleth.sso/Login?target="

--- a/private/app/php/auth.php
+++ b/private/app/php/auth.php
@@ -121,10 +121,16 @@
             // Close LDAP connection
             ldap_close($ldapConn);
 
-            // Extract initials from user's display name
-            $name = $info[0]["displayname"][0];
-            $parts = explode(", ", $name);
-            $initials = substr($parts[1], 0, 1) . substr($parts[0], 0, 1);
+            // Get username
+            if (isset($env['LDAP_DEFAULT_INITIALS']) && !empty($env['LDAP_DEFAULT_INITIALS'])) {
+                // Use default initials
+                $initials = $env['LDAP_DEFAULT_INITIALS'];
+            } else {
+                // Extract initials from user's display name
+                $name = $info[0]["displayname"][0];
+                $parts = explode(", ", $name);
+                $initials = substr($parts[1], 0, 1) . substr($parts[0], 0, 1);
+            }
 
             // Set session variables
             $_SESSION['username'] = $initials;


### PR DESCRIPTION
Implements https://github.com/HAWK-Digital-Environments/HAWKI/issues/75

Introduces new option in the `.env` file. Example usage:
```
; User initials to use for every user. If not set, try to compute initials from LDAP displayname.
LDAP_DEFAULT_INITIALS="UP"
```