### PR TITLE
Introduce email as alternative feedback channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To get started you need to add a configuration file to the project first. Copy t
 | OIDC_LOGOUT_URI | string  | "https://...."                                 | URL to logout from Identity provider                                                                                                                  |
 | OPENAI_API_URL   | string  | "https://api.openai.com/v1/chat/completions" | Open AI URL                                                                                                                                    |
 | OPENAI_API_KEY   | string  | sk-...                                 | Open AI Api key                                                                                                                                    |
+| FEEDBACK_EMAIL | string  | noreply@example.com        | Replaces the builtin feedback form with a mailto: hyperlink.                 |
 | IMPRINT_LOCATION | string  | https://your-university/imprint        | A link to your imprint. Alternatively you can replace the file index.php under /impressum with your own html/ php of your imprint.                 |
 | PRIVACY_LOCATION | string  | https://your-university/privacy-policy | A link to your privacy policy. Alternatively you can replace the file index.php under /datenschutz with your own html/ php of your privacy policy. |
 | TESTUSER         | string | "tester"                                | Set value for testing purposes. Leave TESTUSER and TESTPASSWORD empty or comment them out to disable test user.                    |

--- a/private/.env.example
+++ b/private/.env.example
@@ -21,6 +21,9 @@ SHIBBOLETH_LOGOUT_URL=""
 OPENAI_API_URL="https://api.openai.com/v1/chat/completions"
 OPENAI_API_KEY="sk-..."
 
+# Alternative feedback channel
+; FEEDBACK_EMAIL="noreply@example.com"
+
 # Legal config
 IMPRINT_LOCATION="https://my-univiersity.com/imprint"
 PRIVACY_LOCATION="https://my-univiersity.com/ai-privacy-policy"

--- a/private/pages/interface.php
+++ b/private/pages/interface.php
@@ -178,7 +178,7 @@
 			</svg>
 		</div>
 		<div class="info">
-			<a href="#" id="feedback" onclick="load(this, 'feedback_loader.php')"><?php echo $translation["FeedBack"]; ?></a>
+			<a href="<?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? 'mailto'.$env['FEEDBACK_EMAIL'] : '#'; ?>" id="feedback" <?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? '' : 'onclick="load(this, \'feedback_loader.php\')"'; ?>><?php echo $translation["FeedBack"]; ?></a>
 			<a href="logout"><?php echo $translation["SignOut"]; ?></a>
 			<br>
 			<!-- CHANGE THIS PART TO ONCLICK EVENT TO LOAD THE PAGE IN MESSAGES PANEL.

--- a/private/pages/interface.php
+++ b/private/pages/interface.php
@@ -178,7 +178,7 @@
 			</svg>
 		</div>
 		<div class="info">
-			<a href="<?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? 'mailto'.$env['FEEDBACK_EMAIL'] : '#'; ?>" id="feedback" <?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? '' : 'onclick="load(this, \'feedback_loader.php\')"'; ?>><?php echo $translation["FeedBack"]; ?></a>
+			<a href="<?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? 'mailto:'.$env['FEEDBACK_EMAIL'] : '#'; ?>" id="feedback" <?php echo isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL']) ? '' : 'onclick="load(this, \'feedback_loader.php\')"'; ?>><?php echo $translation["FeedBack"]; ?></a>
 			<a href="logout"><?php echo $translation["SignOut"]; ?></a>
 			<br>
 			<!-- CHANGE THIS PART TO ONCLICK EVENT TO LOAD THE PAGE IN MESSAGES PANEL.

--- a/private/views/feedback_loader.php
+++ b/private/views/feedback_loader.php
@@ -1,5 +1,10 @@
 <?php 
 
+if (isset($env['FEEDBACK_EMAIL']) && !empty($env['FEEDBACK_EMAIL'])) {
+    # Deactivate feedback form if feedback email is used
+    exit;
+}
+
 if (session_status() == PHP_SESSION_NONE) {
     
 }


### PR DESCRIPTION
HAWKI offers a feedback function that posts feedback on the platform for all users to see. The functionality of this function is not explained within HAWKI (and does not appear in the documentation). For data protection reasons (and simpler data privacy statements), we have decided to offer the sending of feedback by e-mail instead.

These code changes switch the behavior between the feedback form and the feedback email via the `FEEDBACK_EMAIL` switch in `.env`. In addition to the code, an extension of the README is also included. The change is downward compatible.