### PR TITLE
Improved code copy behaviour

### DIFF
--- a/private/pages/interface.php
+++ b/private/pages/interface.php
@@ -722,6 +722,30 @@
 				table.parentNode.replaceChild(textNode, table);
 			});
 
+			// Remove code language from copy content
+			if(clone.tagName === "CODE") {
+				const firstChildNode = clone.firstChild;
+				const lastChildNode = clone.lastChild;
+
+				if(firstChildNode && firstChildNode.nodeName === "#text") {
+					// Remove the first node, as it contains the code language
+					// It is possible that the code language is followed by actual code, so check for that
+					if(firstChildNode.textContent.includes("\n")) {
+						firstChildNode.textContent = firstChildNode.textContent.split("\n")[1];
+					} else {
+						clone.removeChild(firstChildNode);
+					}
+				}
+
+				if (lastChildNode && lastChildNode.nodeName === "#text") {
+					// In some cases, there might be markdown content at the end of the code block due to formatting errors
+					const re = "\n?```"
+					if(lastChildNode.textContent.match(re)) {
+						lastChildNode.textContent = lastChildNode.textContent.replace("\n```", "");
+					}
+				}
+			}
+
 
 		// Get the text content of the modified clone
 		const msgTxt = clone.textContent.trim();


### PR DESCRIPTION
Resolves #67 

## Context
This PR removes the coding language from the copied code block, and improves handling of trailing markdown syntax.

## Steps to reproduce
Prompt: A regex in python to replace numbers. Do not give an explanation.

Result (> to prevent markdown formatting):
```
python
import re

text = "Your text with numbers like 123."
result = re.sub(r'\d+', '', text)
print(result)
>```
```

## Current behaviour
The text that's being copied to the clipboard is (> to prevent markdown formatting):
```
python
import re

text = "Your text with numbers like 123."
result = re.sub(r'\d+', '', text)
print(result)
>```
```

## New behaviour
The text that's being copied to the clipboard is:
```
import re

text = "Your text with numbers like 123."
result = re.sub(r'\d+', '', text)
print(result)
```