### PR TITLE
Feat: Custom Language Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .env
 .DS_Store
-/private/custom

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .DS_Store
+/private/custom

--- a/private/app/php/language_controller.php
+++ b/private/app/php/language_controller.php
@@ -4,7 +4,7 @@
     }
     require_once BOOTSTRAP_PATH;
     require_once  LIBRARY_PATH . 'csrf.php';
-    
+
     function setLanguage(){
         //LANGUAGE CHANGE...
         if(isset($_SESSION['language'])){
@@ -14,7 +14,7 @@
             //try to get cookie from last use
             if (isset($_COOKIE['lastLanguage_cookie']) && $_COOKIE['lastLanguage_cookie'] != '') {
                 $language = $_COOKIE['lastLanguage_cookie'];
-            }			
+            }
             //If theres not cookie try env default language
             elseif((file_exists(ENV_FILE_PATH) && parse_ini_file(ENV_FILE_PATH)['DEFAULT_LANGUAGE'] != '')) {
                 $env = parse_ini_file(ENV_FILE_PATH);
@@ -41,6 +41,16 @@
         $languageSanitized = preg_replace('~[^a-zA-Z_]~', '', $language);
         $langFile = file_get_contents(LANGUAGE_PATH . $languageSanitized . '.json');
         $translation = json_decode($langFile, true);
+
+        $customLangFile = CUSTOM_LANGUAGE_PATH . $languageSanitized . '.json';
+
+        if (file_exists ($customLangFile)) {
+
+            $customTranslation = json_decode(file_get_contents($customLangFile), true);
+            $translation = array_merge($translation, $customTranslation);
+
+        }
+
         $_SESSION['translation'] = $translation;
     }
 
@@ -75,6 +85,16 @@
         $_SESSION['language'] = $lang;
         $langFile = file_get_contents(RESOURCES_PATH . "language/{$lang}.json");
         $translation = json_decode($langFile, true);
+
+        $customLangFile = CUSTOM_LANGUAGE_PATH . "{$lang}.json";
+
+        if (file_exists ($customLangFile)) {
+
+            $customTranslation = json_decode(file_get_contents($customLangFile), true);
+            $translation = array_merge($translation, $customTranslation);
+
+        }
+
         $_SESSION['translation'] = $translation;
 
         setcookie('lastLanguage_cookie', $_SESSION['language'], strtotime('2038-01-01'), '/', '', true, true);

--- a/private/bootstrap.php
+++ b/private/bootstrap.php
@@ -2,7 +2,7 @@
     defined('PRIVATE_PATH') || define('PRIVATE_PATH', $_SERVER['DOCUMENT_ROOT']. '/private');
     defined('APPLICATION_PATH') || define('APPLICATION_PATH', PRIVATE_PATH . '/app');
     defined('BASE_URL') || define('BASE_URL', 'localhost:8000/');
-    
+
     define('ENV_FILE_PATH', PRIVATE_PATH . '/.env');
     define('LIBRARY_PATH', APPLICATION_PATH . '/'. 'php/');
     define('RESOURCES_PATH', PRIVATE_PATH . '/' . 'resources/');
@@ -18,3 +18,6 @@
     define('VIEWS_PATH', PRIVATE_PATH . '/' . 'views/' );
     define('LAGNUAGE_CONTROLLER_PATH', LIBRARY_PATH . 'language_controller.php');
     define('LANGUAGE_PATH', RESOURCES_PATH . 'language/');
+    define('CUSTOM_PATH', PRIVATE_PATH . '/' . 'custom/');
+    define('CUSTOM_LANGUAGE_PATH', CUSTOM_PATH . 'language/');
+

--- a/private/custom/language/de_DE.json.example
+++ b/private/custom/language/de_DE.json.example
@@ -1,0 +1,3 @@
+{
+   "AboutHAWKI": "Über HAWKI Custom",
+}

--- a/private/custom/language/de_DE.json.example
+++ b/private/custom/language/de_DE.json.example
@@ -1,3 +1,0 @@
-{
-   "AboutHAWKI": "Über HAWKI",
-}

--- a/private/custom/language/de_DE.json.example
+++ b/private/custom/language/de_DE.json.example
@@ -1,3 +1,3 @@
 {
-   "AboutHAWKI": "Über HAWKI Custom",
+   "AboutHAWKI": "Über HAWKI",
 }

--- a/private/custom/language/readme.md
+++ b/private/custom/language/readme.md
@@ -1,0 +1,5 @@
+Here you can add custom lang files in .json Format.
+
+See private\resources\language\de_DE.json for example.
+
+You only need to add the language variables you want to change to any given custom lang file.


### PR DESCRIPTION
This PR adds a path for custom language files under private/custom/language. Users of HAWKI can place .json language files here and add the language variables they want to change to these custom files. Only those lang variables users want to change need to be present in a custom lang file. I.e. "private/custom/language/de_DE.json". Content of custom lang files is merged with the default language files present under "private/resources/language". If no custom lang file exists the default lang file is used. 

Addes /private/custom to .gitignore to allow users to freely modify custom lang files.