### PR TITLE
Fix processStream() for Azure OpenAI API

### DIFF
--- a/private/pages/interface.php
+++ b/private/pages/interface.php
@@ -589,6 +589,9 @@
 						return;
 					}
 					const jsonChunk = JSON.parse(chunk);
+					// Check required for Azure OpenAI
+					if(!jsonChunk["choices"].length) return false;
+					// Check required for all models
 					if(jsonChunk["choices"][0]["finish_reason"] != null) return false;
 					
 					rawMsg += jsonChunk["choices"][0]["delta"].content;


### PR DESCRIPTION
See https://github.com/HAWK-Digital-Environments/HAWKI/issues/100 by @GaRaOne

Commit https://github.com/HAWK-Digital-Environments/HAWKI/commit/c1e40011172d8380e25a0184aa5429726067e683 crashes for Azure API, because first choices field is an empty array. An additional check is required, otherwise the chat answer remains empty.