### PR TITLE
Fix processStream() for GWDG meta-llama-3.1-8b-instruct

### DIFF
--- a/private/pages/interface.php
+++ b/private/pages/interface.php
@@ -590,6 +590,8 @@
 					}
 					const jsonChunk = JSON.parse(chunk);
 					if(jsonChunk["choices"][0]["finish_reason"] != null) return false;
+					// Required for models with empty content on first response (e.g. meta-llama-3.1-8b-instruct)
+					if(!jsonChunk["choices"][0]["delta"].content) return false;
 					
 					rawMsg += jsonChunk["choices"][0]["delta"].content;
 					document.querySelector(".message:last-child").querySelector(".message-text").innerHTML =  FormatChunk(jsonChunk["choices"][0]["delta"].content);


### PR DESCRIPTION
## Problem
GWDG API result may crash and result in empty answer, because in streaming mode the first content field may be empty.

## Reproduce error
Currently reproducible with the following prompt:

URL: `https://chat-ai.academiccloud.de/v1/chat/completions`
```json
{
    "temperature": 0,
    "max_tokens": 1000,
    "model": "meta-llama-3.1-8b-instruct",
    "stream": false,
    "messages": [
        {
            "role": "system",
            "content": "Hallo-Sager"
        },
        {
            "role": "user",
            "content": "Sag 'Hallo'"
        }
    ]
}
```

First response:
```json
{"id":"chat-e1433d697a0d462ca96cb2a3146247ab","object":"chat.completion.chunk","created":1740156160,"model":"meta-llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant"},"logprobs":null,"finish_reason":null}],"usage":null}
```

Notice the missing field `jsonChunk["choices"][0]["delta"].content`, which HAWKI expects in https://github.com/HAWK-Digital-Environments/HAWKI/blob/main/private/pages/interface.php#L594. The crash message is:
```
Error: TypeError: Cannot read properties of undefined (reading 'replace')
    [...]
    at Array.forEach (<anonymous>)
    at processStream (interface:[...])
```

## Solution
This pull request checks and skips empty content fields.