### PR TITLE
Skip LDAP binding

### DIFF
--- a/app/Services/Auth/LdapService.php
+++ b/app/Services/Auth/LdapService.php
@@ -42,7 +42,7 @@ class LdapService
             }
         
             // Bind to LDAP server
-            if (!@ldap_bind($ldapConn, $ldap_binddn, $ldap_bindpw)) {
+            if ($ldap_binddn && !@ldap_bind($ldapConn, $ldap_binddn, $ldap_bindpw)) {
                 return false;
             }
 


### PR DESCRIPTION
Skip LDAP bind if LDAP_BASE_DN not specified. Some LDAP configurations do not use binding.