### PR TITLE
Define default prompt in translation (=make it adjustable)

### DIFF
--- a/public/js_v2.0.0/ai_chat_functions.js
+++ b/public/js_v2.0.0/ai_chat_functions.js
@@ -2,7 +2,7 @@
 let convMessageTemplate;
 let chatItemTemplate;
 let activeConv;
-let defaultPromt;
+let defaultPrompt;
 let chatlogElement;
 
 function initializeAiChatModule(chatsObject){
@@ -11,12 +11,11 @@ function initializeAiChatModule(chatsObject){
     chatItemTemplate = document.getElementById('selection-item-template');
     chatlogElement = document.querySelector('.chatlog');
 
-    // defaultPromt = "You're a helpful assistant at the HAWK university of applied sciences and arts.";
-    defaultPromt =`Du bist ein intelligentes und unterstützendes KI-Assistenzsystem für alle Hochschulangehörigen der HAWK Hildesheim/Holzminden/Göttingen. Dein Ziel ist es, Studierende, Lehrende, Forschende und Mitarbeitende in ihrer akademischen Arbeit, beim Lernen, Forschen, Lehren und verwalterischen Aufgaben zu unterstützen. Dabei förderst du kollaboratives Arbeiten, wissenschaftliches Denken und eine kreative Problemlösung. Beziehe dich auf wissenschaftliche Methoden und Theorien, argumentiere sachlich und reflektiere kritisch. Sei objektiv und verzichte auf unbegründete Meinungen. Fördere akademische Integrität und unterstütze keine Plagiate. Sei inklusiv, wertschätzend und respektiere Vielfalt.`
+    defaultPrompt = translation.DefaultPrompt;
 
     const systemPromptFields = document.querySelectorAll('.system_prompt_field');
     systemPromptFields.forEach(field => {
-        field.textContent = defaultPromt;
+        field.textContent = defaultPrompt;
     });
 
     chats = chatsObject.original;
@@ -288,7 +287,7 @@ function startNewChat(){
 
     const systemPromptFields = document.querySelectorAll('.system_prompt_field');
     systemPromptFields.forEach(field => {
-        field.textContent = defaultPromt;
+        field.textContent = defaultPrompt;
     });
 
     const lastActive = document.getElementById('chats-list').querySelector('.selection-item.active');

--- a/public/js_v2.0.0/groupchat_functions.js
+++ b/public/js_v2.0.0/groupchat_functions.js
@@ -383,11 +383,9 @@ function openRoomCreatorPanel(){
     }
 
     const roomCreationPanel = document.getElementById('room-creation');
-    // const defaultPromt = "You're a helpful assistant at the HAWK usniversity of applied sciences and arts.";
+    defaultPrompt = translation.DefaultPrompt;
     
-    defaultPromt =`Du bist ein intelligentes und unterstützendes KI-Assistenzsystem für alle Hochschulangehörigen der HAWK Hildesheim/Holzminden/Göttingen. Dein Ziel ist es, Studierende, Lehrende, Forschende und Mitarbeitende in ihrer akademischen Arbeit, beim Lernen, Forschen, Lehren und verwalterischen Aufgaben zu unterstützen. Dabei förderst du kollaboratives Arbeiten, wissenschaftliches Denken und eine kreative Problemlösung. Beziehe dich auf wissenschaftliche Methoden und Theorien, argumentiere sachlich und reflektiere kritisch. Sei objektiv und verzichte auf unbegründete Meinungen. Fördere akademische Integrität und unterstütze keine Plagiate. Sei inklusiv, wertschätzend und respektiere Vielfalt.`
-    
-    roomCreationPanel.querySelector('#system-prompt-input').value = defaultPromt;
+    roomCreationPanel.querySelector('#system-prompt-input').value = defaultPrompt;
     resizeInputField(roomCreationPanel.querySelector('#system-prompt-input'));
 }
 

--- a/resources/language/de_DE.json
+++ b/resources/language/de_DE.json
@@ -1,6 +1,8 @@
 {
     "Guidelines": "Leitfaden zum Umgang mit HAWKI",
-    
+
+    "DefaultPrompt": "Du bist ein intelligentes und unterstützendes KI-Assistenzsystem für alle Hochschulangehörigen der HAWK Hildesheim/Holzminden/Göttingen. Dein Ziel ist es, Studierende, Lehrende, Forschende und Mitarbeitende in ihrer akademischen Arbeit, beim Lernen, Forschen, Lehren und verwalterischen Aufgaben zu unterstützen. Dabei förderst du kollaboratives Arbeiten, wissenschaftliches Denken und eine kreative Problemlösung. Beziehe dich auf wissenschaftliche Methoden und Theorien, argumentiere sachlich und reflektiere kritisch. Sei objektiv und verzichte auf unbegründete Meinungen. Fördere akademische Integrität und unterstütze keine Plagiate. Sei inklusiv, wertschätzend und respektiere Vielfalt.",
+
     "Chat":"Chat",
     "Groupchat":"Gruppenchat",
     "Logout":"Ausloggen",

--- a/resources/language/en_US.json
+++ b/resources/language/en_US.json
@@ -1,6 +1,7 @@
 {
     "Guidelines": "Guidelines for Using HAWKI",
     
+    "DefaultPrompt": "You're a helpful assistant at the HAWK university of applied sciences and arts.",
 
     "Chat":"Chat",
     "Groupchat":"Group Chat",


### PR DESCRIPTION
The default prompt was always in german. Now it's defined in the language file and easily to adjust. Also fixed a typo.