### PR TITLE
Fix: Anonymous LDAP login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,12 +339,16 @@ AUTHENTICATION_METHOD=""
 # LDAP Configuration
 # -------------------------------
 #
+# IMPORTANT
 # LDAP_CONNECTION: Configure the LDAP connection. Currently only "default" is supported (see config/ldap.php)
-# LDAP_HOST: Hostname of the LDAP server
-# LDAP_PORT: Port number of the LDAP server
+# LDAP_HOST: Hostname of the LDAP server with prefix ldap:// or ldaps://
+# LDAP_PORT: Port number of the LDAP server, unencrypted port 389 and encrypted port 636
 # LDAP_USERNAME: Distinguished Name (DN) used for bind operation
 # LDAP_BIND_PW: Password to access the LDAP server
 # LDAP_BASE_DN: Base DN for the LDAP search
+# LDAP_FILTER: Filter required for authentication based on Username
+#
+# OPTIONAL - NOTE: Some optional variables may not be implemented yet
 # LDAP_TIMEOUT: Timeout for LDAP queries in seconds
 # LDAP_SSL: Use SSL to connect to the LDAP server. Not recommended: "true" or "false"
 # LDAP_TLS: Use TLS to connect to the LDAP server. Recommended: "true" or "false"
@@ -352,17 +356,28 @@ AUTHENTICATION_METHOD=""
 # LDAP_LOGGING: Enable logging of LDAP queries: "true" or "false"
 # LDAP_CACHE: Enable caching of LDAP queries: "true" or "false"
 # LDAP_ATTRIBUTES: Attributes required for data extraction (Username, Email Address, Employee Type, Name)
-# LDAP_FILTER: Filter required for authentication based on Username
 # CACHE_DRIVER: Cache driver for caching LDAP queries: "file", ...
 # TEST_USER_LOGIN : Reads the test users list in storage folder before LDAP. Set to true for allowing test access and add tester profile to the json file.
 
 
-#LDAP_CONNECTION= default
-#LDAP_HOST= localhost
-#LDAP_PORT= 389
+#LDAP_CONNECTION=default
+
+#LDAP_HOST=ldaps:// ...
+#LDAP_PORT=636
+
+# For non-anonymous bind:
 #LDAP_USERNAME= cn=user,dc=local,dc=com
 #LDAP_BIND_PW= secret
+
 #LDAP_BASE_DN= dc=local,dc=com
+#LDAP_FILTER= "(|(sAMAccountName=username)(mail=username))"
+
+# Explicitly supported LDAP attributes
+#LDAP_LOGIN_NAME_ATTR=uid
+#LDAP_FULL_NAME_ATTR=cn
+#LDAP_MAIL_ATTR=mail
+#LDAP_EMPLOYEETYPE_ATTR=employeetype
+
 #LDAP_TIMEOUT= 5
 #LDAP_SSL= false
 #LDAP_TLS= false
@@ -370,7 +385,6 @@ AUTHENTICATION_METHOD=""
 #LDAP_LOGGING= true
 #LDAP_CACHE= false
 #LDAP_ATTRIBUTES= cn,mail,employeetype,displayname
-#LDAP_FILTER= "(|(sAMAccountName=username)(mail=username))"
 #CACHE_DRIVER= file
 #TEST_USER_LOGIN=false
 

--- a/app/Services/Auth/LdapService.php
+++ b/app/Services/Auth/LdapService.php
@@ -14,13 +14,16 @@ class LdapService
     public function authenticate($username, $password)
     {
         try {
-            $ldap_host = config('ldap.custom_connection.ldap_host');
-            $ldap_port = config('ldap.custom_connection.ldap_port');
-            $ldap_binddn = config('ldap.custom_connection.ldap_base_dn');
-            $ldap_bindpw = config('ldap.custom_connection.ldap_bind_pw');
-            $ldap_base = config('ldap.custom_connection.ldap_search_dn');
-            $ldap_filter = config('ldap.custom_connection.ldap_filter');
-            $ldap_attributeMap = config('ldap.custom_connection.attribute_map');
+            // may be further integrated as selectable option during login 
+            $connection = config('ldap.connection');
+
+            $ldap_host = config("ldap.$connection.host");
+            $ldap_port = config("ldap.$connection.port");
+            $ldap_bind_dn = config("ldap.$connection.bind_dn");
+            $ldap_bind_pw = config("ldap.$connection.bind_pw");
+            $ldap_base_dn = config("ldap.$connection.base_dn");
+            $ldap_filter = config("ldap.$connection.filter");
+            $ldap_attributeMap = config("ldap.$connection.attribute_map");
 
             // Check if username or password is empty
             if (!$username || !$password) {
@@ -42,13 +45,13 @@ class LdapService
             }
         
             // Bind to LDAP server
-            if (!@ldap_bind($ldapConn, $ldap_binddn, $ldap_bindpw)) {
+            if (!@ldap_bind($ldapConn, $ldap_bind_dn, $ldap_bind_pw)) {
                 return false;
             }
 
             // Search LDAP for user
             $filter = str_replace("username", $username, $ldap_filter);
-            $sr = ldap_search($ldapConn, $ldap_base, $filter);
+            $sr = ldap_search($ldapConn, $ldap_base_dn, $filter);
             if (!$sr) {
                 return false;
             }
@@ -84,10 +87,10 @@ class LdapService
             }
 
             // Example specific logic for display name
-            if (isset($userInfo['displayname'])) {
-                $parts = explode(", ", $userInfo['displayname']);
-                $userInfo['name'] = (isset($parts[1]) ? $parts[1] : '') . " " . (isset($parts[0]) ? $parts[0] : '');
-            }
+            //if (isset($userInfo['name'])) {
+            //    $parts = explode(", ", $userInfo['name']);
+            //    $userInfo['name'] = (isset($parts[1]) ? $parts[1] : '') . " " . (isset($parts[0]) ? $parts[0] : '');
+            //}
             return $userInfo;
         } catch (\Exception $e) {
 

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('LDAP_CONNECTION', 'default'),
+    'connection' => env('LDAP_CONNECTION', 'default'),
 
     /*
     |--------------------------------------------------------------------------
@@ -26,40 +26,20 @@ return [
     |
     */
 
-    'connections' => [
-
-        'default' => [
-            'hosts' => [env('LDAP_HOST', '127.0.0.1')],
-            'username' => env('LDAP_USERNAME', 'cn=user,dc=local,dc=com'),
-            'password' => env('LDAP_PASSWORD', 'secret'),
-            'port' => env('LDAP_PORT', 389),
-            'base_dn' => env('LDAP_BASE_DN', 'dc=local,dc=com'),
-            'timeout' => env('LDAP_TIMEOUT', 5),
-            'use_ssl' => env('LDAP_SSL', false),
-            'use_tls' => env('LDAP_TLS', false),
-            'use_sasl' => env('LDAP_SASL', false),
-            'sasl_options' => [
-                // 'mech' => 'GSSAPI',
-            ],
-        ],
-
-    ],
-
-
-    'custom_connection' =>[
-        'ldap_host' => env('LDAP_HOST'),
-        'ldap_port' => env('LDAP_PORT'),
-        'ldap_base_dn' => env('LDAP_BASE_DN'),
-        'ldap_bind_pw' => env('LDAP_BIND_PW'),
-        'ldap_search_dn' => env('LDAP_SEARCH_DN'),
-        'ldap_filter'=> env('LDAP_FILTER'),
+    'default' => [
+        'host' => env('LDAP_HOST'),
+        'port' => env('LDAP_PORT'),
+        'bind_dn' => env('LDAP_USERNAME'),
+        'bind_pw' => env('LDAP_BIND_PW'),
+        'base_dn' => env('LDAP_BASE_DN'),
+        'filter'=> env('LDAP_FILTER'),
 
         'attribute_map' => [
-            'username' => 'cn',
-            'email' => 'mail',
-            'employeetype' => 'employeetype',
-            'name' => 'displayname',
-        ],
+            'username' => env('LDAP_LOGIN_NAME_ATTR'),
+            'name' => env('LDAP_FULL_NAME_ATTR'),
+            'email' => env('LDAP_MAIL_ATTR'),
+            'employeetype' => env('LDAP_EMPLOYEETYPE_ATTR'),
+        ]
     ],
 
     /*


### PR DESCRIPTION
Fixed anonymous LDAP login by updating bind logic to support null credentials. Corrected improper variable naming and use, e.g., $ldap_binddn wrongly set to ldap_base_dn, now uses proper bind_dn, to follow standard LDAP conventions. Improved config/ldap.php and app/Services/Auth/LdapService.php. Updated also .env.example.