### PR TITLE
Fix: external API crashes on every request (undefined `stream` key)

### DIFF
--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -53,6 +53,7 @@ class StreamController extends Controller
         }
 
         $payload = $validatedData['payload'];
+        $payload['stream'] = false;
 
         // Handle standard response
         $response = $this->aiService->sendRequest($payload);

--- a/tests/Feature/ExternalApiTest.php
+++ b/tests/Feature/ExternalApiTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ExternalApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsTokenUser(): void
+    {
+        Sanctum::actingAs(User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'username' => 'testuser',
+            'publicKey' => '',
+            'employeetype' => 'staff',
+        ]));
+    }
+
+    private function validPayload(): array
+    {
+        return [
+            'payload' => [
+                'model' => 'gpt-4.1-nano',
+                'messages' => [
+                    ['role' => 'user', 'content' => ['text' => 'Hi']],
+                ],
+            ],
+        ];
+    }
+
+    /** Payload without 'stream' must not 500 — see PR #220, ae539aa, ab5eb36. */
+    public function test_external_api_does_not_crash_without_stream_field(): void
+    {
+        $this->actingAsTokenUser();
+
+        $response = $this->postJson('/api/ai-req', $this->validPayload());
+
+        $this->assertNotEquals(500, $response->status());
+    }
+
+    public function test_external_api_rejects_missing_model(): void
+    {
+        $this->actingAsTokenUser();
+
+        $this->postJson('/api/ai-req', [
+            'payload' => [
+                'messages' => [['role' => 'user', 'content' => ['text' => 'Hi']]],
+            ],
+        ])->assertStatus(422);
+    }
+
+    public function test_external_api_rejects_unauthenticated(): void
+    {
+        $this->postJson('/api/ai-req', $this->validPayload())->assertStatus(401);
+    }
+}


### PR DESCRIPTION
`handleExternalRequest` validation strips `stream` from the payload, but all three provider converters access `$rawPayload['stream']` directly, causing an `ErrorException` -> 500 on every call. This is a regression of the fix in 2.0.1 (be45666), lost again during ae539aa. PR adds the same one-line fix (`$payload['stream'] = false`) as be45666 plus a regression test ensuring that a request to api/req-ai doesn't just get a catch-all 500 response.

This is a draft PR as I don't plan to get involved with HAWKI development but still want to provide a full fix and tests which is awkward in an issue. Feel free to close immediately.