### PR TITLE
dev-bug: Fix 'stale' user resolution from singleton. Fix ollama api url. …

### DIFF
--- a/_docker_production/config/model_providers.php
+++ b/_docker_production/config/model_providers.php
@@ -91,8 +91,8 @@ return [
         ],
         'ollama' => [
             'active' => env('OLLAMA_ACTIVE', false),
-            'api_url' => env('OLLAMA_API_URL', 'http://localhost:11434/api/chat'),
-            'ping_url' => env('OLLAMA_API_URL', 'http://localhost:11434/api/tags'),
+            'api_url' => env('OLLAMA_API_URL', 'http://localhost:11434'),
+            'ping_url' => env('OLLAMA_API_URL', 'http://localhost:11434'),
             'models' => require __DIR__ . env('OLLAMA_MODEL_LIST_DIR', '/model_lists/ollama_models.php'),
         ],
         'openWebUi' => [

--- a/app/Models/Scopes/Traits/UserAwareScopeTrait.php
+++ b/app/Models/Scopes/Traits/UserAwareScopeTrait.php
@@ -8,7 +8,6 @@ namespace App\Models\Scopes\Traits;
 use App\Http\Middleware\SystemContextBootingMiddleware;
 use App\Models\User;
 use App\Services\System\Container\SystemEnvironment;
-use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Http\Request;
 
 trait UserAwareScopeTrait
@@ -22,7 +21,7 @@ trait UserAwareScopeTrait
     public function initializeUserAwareScopeTrait(SystemEnvironment $environment): void
     {
         $this->uast_isRunningInConsole = $environment->runningInConsole();
-        $this->uast_currentUserResolver = static fn(Guard $auth) => $auth->user();
+        $this->uast_currentUserResolver = static fn(Request $request) => $request->user();
         $this->uast_onNoUser = static function () {
             tracee();
             abort(403, sprintf("No authenticated user found for applying scope: '%s'.", class_basename(static::class)));

--- a/app/Models/Scopes/Traits/UserAwareScopeTrait.php
+++ b/app/Models/Scopes/Traits/UserAwareScopeTrait.php
@@ -8,6 +8,7 @@ namespace App\Models\Scopes\Traits;
 use App\Http\Middleware\SystemContextBootingMiddleware;
 use App\Models\User;
 use App\Services\System\Container\SystemEnvironment;
+use Illuminate\Contracts\Auth\Factory;
 use Illuminate\Http\Request;
 
 trait UserAwareScopeTrait
@@ -21,7 +22,7 @@ trait UserAwareScopeTrait
     public function initializeUserAwareScopeTrait(SystemEnvironment $environment): void
     {
         $this->uast_isRunningInConsole = $environment->runningInConsole();
-        $this->uast_currentUserResolver = static fn(Request $request) => $request->user();
+        $this->uast_currentUserResolver = static fn(Factory $auth) => $auth->guard()->user();
         $this->uast_onNoUser = static function () {
             tracee();
             abort(403, sprintf("No authenticated user found for applying scope: '%s'.", class_basename(static::class)));

--- a/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTest.php
+++ b/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models\Scopes\Traits;
+
+use App\Models\Scopes\Traits\UserAwareScopeTrait;
+use App\Models\User;
+use App\Services\System\Container\ServiceLocator;
+use App\Services\System\Container\SystemEnvironment;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tests\TestCase;
+use Tests\Unit\Models\Scopes\Traits\UserAwareScopeTraitTestFixtures\UserAwareScopeHost;
+
+#[CoversClass(UserAwareScopeTrait::class)]
+class UserAwareScopeTraitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private UserAwareScopeHost $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mock the request->user() resolver is bound by the framework during the HTTP request lifecycle
+        // (see AuthServiceProvider::registerRequestRebindHandler), which does not run in a unit test.
+        // Mirror that wiring here so $request->user() resolves through the auth manager.
+        $this->app['request']->setUserResolver(fn ($guard = null) => $this->app['auth']->guard($guard)->user());
+
+        $this->sut = new UserAwareScopeHost();
+        $this->sut->initializeServiceLocatingScopeTrait($this->app->make(ServiceLocator::class));
+        $this->sut->initializeUserAwareScopeTrait($this->app->make(SystemEnvironment::class));
+    }
+
+    public function testItResolvesUserFromRequestEvenWhenDefaultGuardSingletonIsStale(): void
+    {
+        $user = User::factory()->create();
+
+        // Reproduce the production ordering: the Illuminate\Contracts\Auth\Guard binding
+        // (the auth.driver singleton) materializes as the default 'web' guard BEFORE the
+        // default driver is switched to 'sanctum'. The web guard never holds the
+        // token-authenticated user, so resolving via Guard would return null here.
+        $this->app->make(Guard::class);
+
+        // SystemContextBootingMiddleware then authenticates via Sanctum and switches the default.
+        $this->actingAs($user, 'sanctum');
+
+        self::assertSame($user, $this->sut->exposeCurrentUser());
+    }
+
+    public function testItReturnsNullWhenNoUserIsAuthenticated(): void
+    {
+        self::assertNull($this->sut->exposeCurrentUser());
+    }
+}

--- a/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTest.php
+++ b/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTest.php
@@ -55,4 +55,18 @@ class UserAwareScopeTraitTest extends TestCase
     {
         self::assertNull($this->sut->exposeCurrentUser());
     }
+
+    public function testItResolvesUserInConsoleWhereRequestHasNoUserResolver(): void
+    {
+        // Console reality: unlike the HTTP lifecycle, the request's user-resolver is NOT
+        // wired to the auth manager. A command sets the user directly on the guard via
+        // auth()->setUser() (see CreateSanctumTokenForUser:82). Undo setUp()'s HTTP-style
+        // wiring so we reproduce a real console request.
+        $this->app['request']->setUserResolver(static fn ($guard = null) => null);
+
+        $user = User::factory()->create();
+        $this->app['auth']->setUser($user);
+
+        self::assertSame($user, $this->sut->exposeCurrentUser());
+    }
 }

--- a/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTestFixtures/UserAwareScopeHost.php
+++ b/tests/Unit/Models/Scopes/Traits/UserAwareScopeTraitTestFixtures/UserAwareScopeHost.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models\Scopes\Traits\UserAwareScopeTraitTestFixtures;
+
+use App\Models\Scopes\Traits\UserAwareScopeTrait;
+use App\Models\User;
+
+class UserAwareScopeHost
+{
+    use UserAwareScopeTrait;
+
+    public function exposeCurrentUser(): User|null
+    {
+        return $this->getCurrentUser();
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     },
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.ts'],
             refresh: true
         }),
         vitePluginBreakpoints(


### PR DESCRIPTION
- SystemContextBootingMiddleware changes the default driver mid-request — it authenticates the Bearer token, then calls setDefaultDriver('sanctum') but Guard singleton returned no user
-  vite app.js -> app.ts
- adjust ollama urls since ollama provider builds chat url from base url https://github.com/laravel/ai/blob/259b92a7b339dbc849c8bc3055042760a31f7efc/tests/Feature/Providers/Ollama/BaseUrlTest.php#L9-L32
