### PR TITLE
dev-bug: Fix doc links

### DIFF
--- a/_documentation/100-GettingStarted/100-Local-Installation.md
+++ b/_documentation/100-GettingStarted/100-Local-Installation.md
@@ -97,7 +97,7 @@ At this point the dependency packages should be installed. `node_modules` and `v
 ### Configuration
 
 To configure the environment variable open `.env` file in the root directory.
-For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-dot-Env.md) of the
+For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-Dot-Env.md) of the
 documentation.
 
 > <details>

--- a/_documentation/200-Configuration/200-Model-Configuration-Variables.md
+++ b/_documentation/200-Configuration/200-Model-Configuration-Variables.md
@@ -516,6 +516,6 @@ MODELS_GWDG_QWEN3_OMNI_30B_A3B_INSTRUCT_TOOLS_FILE_UPLOAD=true
 ## Related Documentation
 
 - [AI Models & Tools](300-AI-Models-and-Tools.md) — complete architecture guide for models and tools, including MCP servers and function-calling tools
-- [dot Env Configuration](100-dot-Env.md) — complete `.env` reference
+- [dot Env Configuration](100-Dot-Env.md) — complete `.env` reference
 - [HAWKI CLI](700-HAWKI-CLI.md) — CLI command reference
 - [Backend → AI Service Layer](../500-Backend/500-AI-Service-Layer/index.md) — provider adapter and model enrichment implementation

--- a/_documentation/200-Configuration/300-AI-Models-and-Tools.md
+++ b/_documentation/200-Configuration/300-AI-Models-and-Tools.md
@@ -416,5 +416,5 @@ For further details on individual components see:
 - [Backend → AI Service Layer](../500-Backend/500-AI-Service-Layer/index.md) — current provider adapter implementation
 - [Backend → Provider Adapters](../500-Backend/500-AI-Service-Layer/100-Provider-Adapters.md) — `ProviderAdapterInterface` and `ProviderAdapterRegistry`
 - [Model Configuration Variables](200-Model-Configuration-Variables.md) — environment variable reference for fine-grained model control
-- [dot Env](100-dot-Env.md) — complete `.env` reference
+- [dot Env](100-Dot-Env.md) — complete `.env` reference
 - [HAWKI CLI](700-HAWKI-CLI.md) — full CLI command reference

--- a/_documentation/300-Deployment/100-Apache-Server.md
+++ b/_documentation/300-Deployment/100-Apache-Server.md
@@ -136,7 +136,7 @@ At this point, the project is transferred to the server, but you may encounter a
 ### Configuration
 
 To configure the environment variable open `.env` file in the root directory.
-For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-dot-Env.md) of the
+For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-Dot-Env.md) of the
 documentation.
 
 > <details>

--- a/_documentation/300-Deployment/200-Nginx-Server.md
+++ b/_documentation/300-Deployment/200-Nginx-Server.md
@@ -275,7 +275,7 @@ At this point, the project is transferred to the server, but you may encounter a
 ### Configuration
 
 To configure the environment variable open `.env` file in the root directory.
-For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-dot-Env.md) of the
+For a complete guide to environment variables please refer to [.env section](../200-Configuration/100-Dot-Env.md) of the
 documentation.
 
 > <details>


### PR DESCRIPTION
Fixes link errors when running `./bin/env docs watch`