### PR TITLE
Reuse legacy file converter interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,7 +168,7 @@ OPEN_WEB_UI_API_KEY=
 # GWDG_FILE_CONVERTER_API_URL       URL to the GWDG converter. 'https://chat-ai.academiccloud.de/v1/documents/convert'
 
 FILE_CONVERTER=hawki_converter
-HAWKI_FILE_CONVERTER_API_URL=127.0.0.1:8001/extract
+HAWKI_FILE_CONVERTER_API_URL=127.0.0.1/extract
 HAWKI_FILE_CONVERTER_API_KEY=
 GWDG_FILE_CONVERTER_API_URL='https://chat-ai.academiccloud.de/v1/documents/convert'
 

--- a/_documentation/200-Configuration/100-Dot-Env.md
+++ b/_documentation/200-Configuration/100-Dot-Env.md
@@ -109,7 +109,7 @@ Configuration for document conversion services. Choose between HAWIK's built-in 
 | Variable                     | Default Value                                         | Description                                           |
 |------------------------------|-------------------------------------------------------|-------------------------------------------------------|
 | FILE_CONVERTER               | hawki_converter                                       | Converter to use: "hawki_converter" or "gwdg_docling" |
-| HAWKI_FILE_CONVERTER_API_URL | 127.0.0.1:8001/extract                                | URL to the hosted HAWKI converter service             |
+| HAWKI_FILE_CONVERTER_API_URL | 127.0.0.1/extract                                | URL to the hosted HAWKI converter service             |
 | HAWKI_FILE_CONVERTER_API_KEY | 123456                                                | API key for the HAWKI converter service               |
 | GWDG_FILE_CONVERTER_API_URL  | https://chat-ai.academiccloud.de/v1/documents/convert | URL to the GWDG Docling converter service             |
 

--- a/_documentation/200-Configuration/200-Model-Configuration-Variables.md
+++ b/_documentation/200-Configuration/200-Model-Configuration-Variables.md
@@ -232,7 +232,7 @@ File upload requires a working converter:
 
 ```bash
 FILE_CONVERTER=hawki_converter
-HAWKI_FILE_CONVERTER_API_URL=127.0.0.1:8001/extract
+HAWKI_FILE_CONVERTER_API_URL=127.0.0.1/extract
 HAWKI_FILE_CONVERTER_API_KEY=your-key
 
 # Or use GWDG Docling:

--- a/app/Console/Commands/FileStorageConverterTypesList.php
+++ b/app/Console/Commands/FileStorageConverterTypesList.php
@@ -27,7 +27,26 @@ class FileStorageConverterTypesList extends Command
      * Execute the console command.
      */
     public function handle(FileConverterInterface $converter): void
-    {
+    {   
+
+        $config = app()->get('config');
+
+        $converterType = $config->get('file_converter.default');
+        $converterConfig = $config->get("file_converter.converters.$converterType");
+        if(empty($converterConfig['class'])){
+            $this -> warn("No converter class configured for '{$converterType}'.");
+            return;
+        }
+        $converterClass = $converterConfig["class"];
+
+        if(!$converterClass::isValidConfig($converterConfig)){
+            $this -> warn("Converter config for '{$converterType}'");
+            return;
+        }
+
+        $converter = app()->make($converterClass, ['config' => $converterConfig]);
+        $converter->setConfig($converterConfig);
+
         if (!$converter->isAvailable()) {
             $this->warn('No file converter is currently installed or available.');
             return;

--- a/app/Console/Commands/FileStorageConverterTypesList.php
+++ b/app/Console/Commands/FileStorageConverterTypesList.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands;
 
+use App\Services\FileConverter\Interfaces\FileConverterExtensionInterface;
 use App\Services\FileConverter\Interfaces\FileConverterInterface;
 use Illuminate\Console\Command;
 use Symfony\Component\Mime\MimeTypes;
@@ -10,16 +13,14 @@ class FileStorageConverterTypesList extends Command
 {
     /**
      * The name and signature of the console command.
-     *
-     * @var string
      */
-    protected $signature = 'filestorage:converter:types:list
-                            {--extensions : Return file extensions instead of MIME types}';
+    protected $signature = <<<'EOD'
+filestorage:converter:types:list
+                            {--extensions : Return file extensions instead of MIME types}
+EOD;
 
     /**
      * The console command description.
-     *
-     * @var string
      */
     protected $description = 'List all MIME types (or file extensions) supported by the active file converter.';
 
@@ -27,48 +28,74 @@ class FileStorageConverterTypesList extends Command
      * Execute the console command.
      */
     public function handle(FileConverterInterface $converter): void
-    {   
-
-        $config = app()->get('config');
-
-        $converterType = $config->get('file_converter.default');
-        $converterConfig = $config->get("file_converter.converters.$converterType");
-        if(empty($converterConfig['class'])){
-            $this -> warn("No converter class configured for '{$converterType}'.");
-            return;
-        }
-        $converterClass = $converterConfig["class"];
-
-        if(!$converterClass::isValidConfig($converterConfig)){
-            $this -> warn("Converter config for '{$converterType}'");
-            return;
-        }
-
-        $converter = app()->make($converterClass, ['config' => $converterConfig]);
-        $converter->setConfig($converterConfig);
-
+    {
         if (!$converter->isAvailable()) {
             $this->warn('No file converter is currently installed or available.');
+
             return;
         }
 
-        $mimeTypes = array_values(array_unique($converter->getAllowedMimeTypes()));
+        $convChain = $this->getConverterChain($converter);
+        $seenMimes = [];
+
+        foreach ($convChain as $convLayer) {
+            $addedMimeTypes = array_values(array_diff($convLayer->getAllowedMimeTypes(), $seenMimes));
+            $seenMimes = array_unique(array_merge($seenMimes, $addedMimeTypes));
+            $this->showConverterInfo($convLayer, $addedMimeTypes);
+        }
+    }
+
+    /**
+     * Return the file converters. The nested converters are returned at the beginning.
+     */
+    private function getConverterChain(FileConverterInterface $converter): array
+    {
+        if (!$converter instanceof FileConverterExtensionInterface) {
+            return [$converter];
+        }
+
+        return array_merge(
+            $this->getConverterChain($converter->getInnerConverter()),
+            [$converter],
+        );
+    }
+
+    /**
+     * Prints one labelled block for a converter layer.
+     *
+     * @param FileConverterInterface $converter the file converter class to print info for
+     * @param list<string>           $mimeTypes MIME types contributed by this layer
+     */
+    private function showConverterInfo(FileConverterInterface $converter, array $mimeTypes): void
+    {
+        $this->line('');
+        $this->line($converter::class . ':');
+
+        if (empty($mimeTypes)) {
+            $this->line('  (No added types)');
+
+            return;
+        }
+
+        $values = $mimeTypes;
 
         if ($this->option('extensions')) {
             $symfony = new MimeTypes();
             $extensions = [];
+
             foreach ($mimeTypes as $mime) {
                 foreach ($symfony->getExtensions($mime) as $ext) {
                     $extensions[] = $ext;
                 }
             }
-            $extensions = array_values(array_unique($extensions));
-            sort($extensions);
 
-            $this->line(implode(PHP_EOL, $extensions));
-        } else {
-            sort($mimeTypes);
-            $this->line(implode(PHP_EOL, $mimeTypes));
+            $values = array_values(array_unique($extensions));
+        }
+
+        sort($values);
+
+        foreach ($values as $value) {
+            $this->line('  ' . $value);
         }
     }
 }

--- a/app/Services/FileConverter/Handlers/AbstractFileConverter.php
+++ b/app/Services/FileConverter/Handlers/AbstractFileConverter.php
@@ -51,4 +51,15 @@ abstract class AbstractFileConverter implements FileConverterInterface
     {
         return false;
     }
+
+    /**
+     * Resolves the HTTP timeout (in seconds) applied to the converter's main conversion request.
+     *
+     * Returns the per-converter `timeout` config value when present, otherwise falls back to
+     * the 60-second default.
+     */
+    protected function getRequestTimeout(): int
+    {
+        return isset($this->config['timeout']) ? (int) $this->config['timeout'] : 60;
+    }
 }

--- a/app/Services/FileConverter/Handlers/GwdgDoclingConverter.php
+++ b/app/Services/FileConverter/Handlers/GwdgDoclingConverter.php
@@ -44,7 +44,9 @@ class GwdgDoclingConverter extends AbstractFileConverter
      * - `markdown` — extracted text; emitted as `{filename}.md`.
      * - `images`   — optional array of base64-encoded images; each emitted as its own FileReference.
      *
-     * The request uses a 240-second timeout because large documents can take significant time to process.
+     * The request uses the converter's configured timeout (defaulting to 240 seconds via
+     * {@see AbstractFileConverter::getRequestTimeout()}) because large documents can take
+     * significant time to process.
      *
      * @throws ConversionFailedException if the API returns a non-2xx response.
      */
@@ -54,7 +56,7 @@ class GwdgDoclingConverter extends AbstractFileConverter
             'Authorization' => 'Bearer ' . $this->config['api_key'],
             'Accept' => 'application/json',
         ])
-            ->timeout(240)
+            ->timeout($this->getRequestTimeout())
             ->attach('document', $file->getStream(), $file->getOriginalFilename())
             ->post($this->config['api_url']);
 

--- a/app/Services/FileConverter/Handlers/HawkiDocConverter.php
+++ b/app/Services/FileConverter/Handlers/HawkiDocConverter.php
@@ -41,7 +41,7 @@ class HawkiDocConverter extends AbstractFileConverter {
     {
         return $this->cache->remember(
             key: $this->cacheKey,
-            ttl: (new Carbon($this-> clock->now()))->addDay(),
+            ttl: (new Carbon($this->clock->now()))->addDay(),
             callback: function () {
                 $response = Http::withHeaders([
                     'Authorization' => 'Bearer ' . $this->config['api_key'],

--- a/app/Services/FileConverter/Handlers/HawkiDocConverter.php
+++ b/app/Services/FileConverter/Handlers/HawkiDocConverter.php
@@ -3,32 +3,84 @@ declare(strict_types=1);
 
 namespace App\Services\FileConverter\Handlers;
 
-use App\Services\FileConverter\Exception\ConversionFailedException;
 use App\Services\Storage\Values\FileCollection;
 use App\Services\Storage\Values\FileReference;
-use Exception;
-use Illuminate\Http\Client\ConnectionException;
+use App\Services\System\Http\UrlResolver;
+use Carbon\Carbon;
+use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Http;
+use Psr\Clock\ClockInterface;
+use App\Services\FileConverter\Exception\ConversionFailedException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use Symfony\Component\Mime\MimeTypes;
 use ZipArchive;
+use Symfony\Component\Mime\MimeTypes;use Symfony\Component\Clock\Clock;
+use Exception;
 
-/**
- * Converter that delegates to the HAWKI internal document conversion service.
- *
- * Documents are uploaded via multipart HTTP POST with Bearer-token authentication.
- * The service responds with a ZIP archive whose contents are extracted to a temporary
- * directory; each extracted file is returned as a {@see FileReference} pointing to its
- * local disk path. Temporary files are cleaned up via a registered shutdown function
- * so they are never left on disk after the request completes.
- *
- * Required config keys (under `file_converter.converters.hawki_converter`):
- *   - `api_url` — full URL of the conversion endpoint
- *   - `api_key` — Bearer token for API authentication (non-empty string)
- */
-class HawkiDocConverter extends AbstractFileConverter
-{
+
+class HawkiDocConverter extends AbstractFileConverter {
+
+    /**
+     * Cached information supplied by service endpoint.
+     */
+    protected string $cacheKey = "hawki_converter_service_info";
+
+    public function __construct(
+        private readonly Repository $cache,
+        private readonly ClockInterface $clock = new Clock()   
+    ) {
+
+    }
+
+    /**
+     * Collects and returns a cached version of the service description endpoint of the 
+     * HAWKI file converter endpoint (`/`
+     * @return array  
+     */
+    protected function getServiceInfo(): array
+    {
+        return $this->cache->remember(
+            key: $this->cacheKey,
+            ttl: (new Carbon($this-> clock->now()))->addDay(),
+            callback: function () {
+                $response = Http::withHeaders([
+                    'Authorization' => 'Bearer ' . $this->config['api_key'],
+                    'Accept' => 'application/json',
+                ])->get(UrlResolver::baseUrl($this->config['api_url']));
+                $serviceInfo = $response->json();
+                return $serviceInfo;
+            }
+        );
+    }
+
+
+    /**
+     * Returns the MIME types accepted by the HAWKI converter.
+     *
+     * @return string[] Lowercase MIME type strings.
+     */
+    public function getAllowedMimeTypes(): array
+    {
+        $mime = new MimeTypes();
+        
+        $getMimeTypesFromFileExt = fn(string $fileExt): array => $mime->getMimeTypes(ltrim($fileExt,  '.'));
+
+        $mimeTypes = array_values(array_unique(array_merge(
+            ...array_map($getMimeTypesFromFileExt, $this->getServiceInfo()["supported_formats"]
+        ))));
+        
+        return $mimeTypes;
+    }
+
+    /**
+     * Always returns true — the HAWKI converter is considered available as long as its config is valid.
+     * Actual connectivity is not checked; HTTP errors during {@see convert()} will throw instead.
+     */
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+    
     /**
      * @inheritDoc
      * Requires both a valid `api_url` and a non-empty `api_key`.
@@ -43,20 +95,30 @@ class HawkiDocConverter extends AbstractFileConverter
     }
 
     /**
-     * Returns the MIME types accepted by the HAWKI converter: PDF, DOC, and DOCX.
+     * Writes the raw ZIP binary to a temp file, extracts it into `$extractToDirectory`,
+     * then removes the temp file. Throws {@see ConversionFailedException} when the archive
+     * cannot be opened.
      *
-     * @return string[] Lowercase MIME type strings.
+     * @param string $zipContent  Raw binary content of the ZIP archive.
+     * @param string $extractToDirectory  Absolute path to an existing directory.
      */
-    public function getAllowedMimeTypes(): array
+    public function unzipContent(string $zipContent, string $extractToDirectory): bool
     {
-        $mime = new MimeTypes();
+        $tmpZip = tempnam(sys_get_temp_dir(), 'unzipped_') . '.zip';
+        file_put_contents($tmpZip, $zipContent);
 
-        return [
-            ...$mime->getMimeTypes('pdf'),
-            ...$mime->getMimeTypes('doc'),
-            ...$mime->getMimeTypes('docx'),
-        ];
+        $zip = new ZipArchive();
+        if ($zip->open($tmpZip) === true) {
+            $zip->extractTo($extractToDirectory);
+            $zip->close();
+            unlink($tmpZip);
+            return true;
+        } else {
+            unlink($tmpZip);
+            throw ConversionFailedException::forString($this, "Failed to open ZIP file.");
+        }
     }
+
 
     /**
      * POSTs the file to the HAWKI converter and unpacks the returned ZIP archive.
@@ -67,7 +129,6 @@ class HawkiDocConverter extends AbstractFileConverter
      *
      * @throws ConversionFailedException if the API returns a non-2xx response, the temporary
      *         directory cannot be created, or the ZIP archive cannot be opened.
-     * @throws ConnectionException if the HTTP connection to the API fails.
      * @throws Exception if PHP's ZipArchive extension encounters an unexpected error.
      */
     public function convert(FileReference $file): FileCollection
@@ -76,11 +137,11 @@ class HawkiDocConverter extends AbstractFileConverter
             'Authorization' => 'Bearer ' . $this->config['api_key'],
             'Accept' => 'application/json',
         ])
+            ->timeout($this->getRequestTimeout())
             ->attach('file', $file->getStream(), $file->getOriginalFilename())
             ->post($this->config['api_url']);
 
         if (!$response->successful()) {
-            \Log::error('PDF extraction failed: ' . $response->body());
             throw ConversionFailedException::forFailedResponse($this, $response);
         }
 
@@ -114,39 +175,5 @@ class HawkiDocConverter extends AbstractFileConverter
         });
 
         return new FileCollection(...$files);
-    }
-
-    /**
-     * Writes the raw ZIP binary to a temp file, extracts it into `$extractToDirectory`,
-     * then removes the temp file. Throws {@see ConversionFailedException} when the archive
-     * cannot be opened.
-     *
-     * @param string $zipContent  Raw binary content of the ZIP archive.
-     * @param string $extractToDirectory  Absolute path to an existing directory.
-     */
-    private function unzipContent(string $zipContent, string $extractToDirectory): bool
-    {
-        $tmpZip = tempnam(sys_get_temp_dir(), 'unzipped_') . '.zip';
-        file_put_contents($tmpZip, $zipContent);
-
-        $zip = new ZipArchive();
-        if ($zip->open($tmpZip) === true) {
-            $zip->extractTo($extractToDirectory);
-            $zip->close();
-            unlink($tmpZip);
-            return true;
-        } else {
-            unlink($tmpZip);
-            throw ConversionFailedException::forString($this, "Failed to open ZIP file.");
-        }
-    }
-
-    /**
-     * Always returns true — the HAWKI converter is considered available as long as its config is valid.
-     * Actual connectivity is not checked; HTTP errors during {@see convert()} will throw instead.
-     */
-    public function isAvailable(): bool
-    {
-        return true;
     }
 }

--- a/app/Services/FileConverter/Handlers/KreuzbergConverter.php
+++ b/app/Services/FileConverter/Handlers/KreuzbergConverter.php
@@ -83,7 +83,9 @@ class KreuzbergConverter extends AbstractFileConverter
                 'files',
                 $file->getStream(),
                 $file->getOriginalFilename()
-            )->post(
+            )
+                ->timeout($this->getRequestTimeout())
+                ->post(
                 $this->config['api_url'] . '/extract',
                 [
                     'config' => json_encode(

--- a/app/Services/FileConverter/Interfaces/FileConverterExtensionInterface.php
+++ b/app/Services/FileConverter/Interfaces/FileConverterExtensionInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\FileConverter\Interfaces;
+
+interface FileConverterExtensionInterface extends FileConverterInterface
+{
+    /**
+     * Returns the inner file converter.
+     */
+    public function getInnerConverter(): FileConverterInterface;
+}

--- a/app/Services/FileConverter/Interfaces/FileConverterInterface.php
+++ b/app/Services/FileConverter/Interfaces/FileConverterInterface.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace App\Services\FileConverter\Interfaces;
 
-use App\Services\FileConverter\Handlers\KreuzbergConverter;
-use App\Services\FileConverter\Utils\ImagePreProcessingConverter;
 use App\Services\Storage\Values\FileCollection;
 use App\Services\Storage\Values\FileReference;
 

--- a/app/Services/FileConverter/Utils/ImagePreProcessingConverter.php
+++ b/app/Services/FileConverter/Utils/ImagePreProcessingConverter.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
+// @php-cs-fixer-ignore error_suppression
 
 namespace App\Services\FileConverter\Utils;
 
-
+use App\Services\FileConverter\Interfaces\FileConverterExtensionInterface;
 use App\Services\FileConverter\Interfaces\FileConverterInterface;
 use App\Services\Storage\Values\FileCollection;
 use App\Services\Storage\Values\FileReference;
@@ -28,20 +30,19 @@ use Symfony\Component\Mime\MimeTypes;
  * All binary paths are configurable via {@see \App\Providers\FileConverterServiceProvider}
  * and the `file_converter.binaries` config key.
  */
-readonly class ImagePreProcessingConverter implements FileConverterInterface
+readonly class ImagePreProcessingConverter implements FileConverterExtensionInterface
 {
     private array $imagickMimeTypes;
     private array $imagickGhostscriptMimeTypes;
 
     public function __construct(
         private FileConverterInterface $concreteConverter,
-        private LoggerInterface        $logger,
-        private Repository             $cache,
-        private string                 $rsvgConvertBinary = 'rsvg-convert',
-        private string                 $imageMagickBinary = 'convert',
-        private string                 $ghostscriptBinary = 'gs',
-    )
-    {
+        private LoggerInterface $logger,
+        private Repository $cache,
+        private string $rsvgConvertBinary = 'rsvg-convert',
+        private string $imageMagickBinary = 'convert',
+        private string $ghostscriptBinary = 'gs',
+    ) {
         $mime = new MimeTypes();
         $this->imagickGhostscriptMimeTypes = array_merge(
             $mime->getMimeTypes('ai'),
@@ -70,6 +71,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
             // Check if rsvg-convert is installed on the machine
             $found = exec('which ' . escapeshellarg($this->rsvgConvertBinary)) !== '';
             $this->logger->debug('SVG conversion tool found: ' . ($found ? 'yes' : 'no'));
+
             return $found;
         });
     }
@@ -86,6 +88,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         return $this->cache->remember('common-image-format-extractor.hasImagemagickCli', 60 * 60 * 24, function () {
             $found = exec('which ' . escapeshellarg($this->imageMagickBinary)) !== '';
             $this->logger->debug('ImageMagick CLI conversion tool found: ' . ($found ? 'yes' : 'no'));
+
             return $found;
         });
     }
@@ -101,25 +104,13 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         return $this->cache->remember('common-image-format-extractor.hasGhostscriptCli', 60 * 60 * 24, function () {
             $found = exec('which ' . escapeshellarg($this->ghostscriptBinary)) !== '';
             $this->logger->debug('Ghostscript CLI tool found: ' . ($found ? 'yes' : 'no'));
+
             return $found;
         });
     }
 
     /**
-     * Returns the ImageMagick-supported MIME types that are currently available,
-     * excluding PostScript-based formats when Ghostscript is not installed.
-     */
-    private function getAvailableImagickMimeTypes(): array
-    {
-        $types = $this->imagickMimeTypes;
-        if ($this->canConvertWithGhostscript()) {
-            $types = array_merge($types, $this->imagickGhostscriptMimeTypes);
-        }
-        return $types;
-    }
-
-    /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static function isValidConfig(array $config): bool
     {
@@ -127,7 +118,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function setConfig(array $config): void
     {
@@ -135,7 +126,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function convert(FileReference $file): FileCollection
     {
@@ -153,7 +144,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
 
         if ($shouldUsePreProcessor
             && $this->canConvertWithImagick()
-            && in_array($file->getMimeType(), $this->getAvailableImagickMimeTypes(), true)
+            && \in_array($file->getMimeType(), $this->getAvailableImagickMimeTypes(), true)
         ) {
             return $this->convertWithImagick($file);
         }
@@ -163,6 +154,77 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         }
 
         return new FileCollection();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAvailable(): bool
+    {
+        return $this->canConvertSvg() || $this->canConvertWithImagick() || $this->concreteConverter->isAvailable();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllowedMimeTypes(): array
+    {
+        $types = [];
+        $mime = new MimeTypes();
+
+        if ($this->canConvertSvg()) {
+            $types = array_merge($types, $mime->getMimeTypes('svg'));
+        }
+
+        if ($this->canConvertWithImagick()) {
+            $types = array_merge($types, $this->getAvailableImagickMimeTypes());
+        }
+
+        return array_unique(array_merge(
+            $types,
+            $this->concreteConverter->getAllowedMimeTypes(),
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function canConvertMimetype(string $mimetype): bool
+    {
+        $mimeTypes = $this->getAllowedMimeTypes();
+
+        return \in_array($mimetype, $mimeTypes, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function wouldLikeSomeoneElseToConvertMimetype(string $mimetype): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInnerConverter(): FileConverterInterface
+    {
+        return $this->concreteConverter;
+    }
+
+    /**
+     * Returns the ImageMagick-supported MIME types that are currently available,
+     * excluding PostScript-based formats when Ghostscript is not installed.
+     */
+    private function getAvailableImagickMimeTypes(): array
+    {
+        $types = $this->imagickMimeTypes;
+
+        if ($this->canConvertWithGhostscript()) {
+            $types = array_merge($types, $this->imagickGhostscriptMimeTypes);
+        }
+
+        return $types;
     }
 
     /**
@@ -178,7 +240,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         $pngPath = sys_get_temp_dir() . '/' . uniqid('converted_', true) . '.png';
 
         // Automatically clean up the temporary files after the request is complete
-        register_shutdown_function(static function () use ($svgPath, $pngPath) {
+        register_shutdown_function(static function () use ($svgPath, $pngPath): void {
             @unlink($svgPath);
             @unlink($pngPath);
         });
@@ -186,10 +248,10 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         $result = exec(
             escapeshellarg($this->rsvgConvertBinary) . ' -u -f png -o ' . escapeshellarg($pngPath) . ' ' . escapeshellarg($svgPath) . ' 2>&1',
             $output,
-            $returnVar
+            $returnVar,
         );
 
-        if ($returnVar !== 0) {
+        if (0 !== $returnVar) {
             $this->logger->error('Failed to convert SVG to JPG', [
                 'svgPath' => $svgPath,
                 'pngPath' => $pngPath,
@@ -199,7 +261,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
             ]);
         }
 
-        $filenameWithoutExt = pathinfo($file->getOriginalFilename(), PATHINFO_FILENAME);
+        $filenameWithoutExt = pathinfo($file->getOriginalFilename(), \PATHINFO_FILENAME);
         $extractFilename = $filenameWithoutExt . '.png';
         $pngRef = FileReference::fromDisk($pngPath, $extractFilename);
         $results = [$pngRef];
@@ -212,6 +274,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
                 'result' => $result,
                 'returnVar' => $returnVar,
             ]);
+
             return new FileCollection();
         }
 
@@ -236,7 +299,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
     private function convertWithImagick(FileReference $file): FileCollection
     {
         // Write the source to a temp file so the CLI tool can read it.
-        $ext = pathinfo($file->getOriginalFilename(), PATHINFO_EXTENSION) ?: 'bin';
+        $ext = pathinfo($file->getOriginalFilename(), \PATHINFO_EXTENSION) ?: 'bin';
         $inputPath = sys_get_temp_dir() . '/' . uniqid('imagick_in_', true) . '.' . $ext;
         file_put_contents($inputPath, $file->getContent());
 
@@ -251,7 +314,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
 
         exec($cmd . ' 2>&1', $output, $returnVar);
 
-        if ($returnVar !== 0) {
+        if (0 !== $returnVar) {
             $this->logger->error('Failed to convert file with ImageMagick CLI', [
                 'inputPath' => $inputPath,
                 'outputPattern' => $outputPattern,
@@ -259,6 +322,7 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
                 'returnVar' => $returnVar,
             ]);
             @unlink($inputPath);
+
             return new FileCollection();
         }
 
@@ -273,16 +337,18 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
                 'output' => $output,
             ]);
             @unlink($inputPath);
+
             return new FileCollection();
         }
 
         $filesToCleanUp = [$inputPath, ...$outputFiles];
-        $filenameWithoutExt = pathinfo($file->getOriginalFilename(), PATHINFO_FILENAME);
+        $filenameWithoutExt = pathinfo($file->getOriginalFilename(), \PATHINFO_FILENAME);
         $results = [];
         $idx = 0;
+
         foreach ($outputFiles as $outputFile) {
             $extractFilename = $filenameWithoutExt . '-' . $idx . '.jpg';
-            $idx++;
+            ++$idx;
             $jpgRef = FileReference::fromDisk($outputFile, $extractFilename);
             $results[] = $jpgRef;
 
@@ -293,60 +359,12 @@ readonly class ImagePreProcessingConverter implements FileConverterInterface
         }
 
         // Automatically clean up the temporary files after the request is complete
-        register_shutdown_function(static function () use ($filesToCleanUp) {
+        register_shutdown_function(static function () use ($filesToCleanUp): void {
             foreach ($filesToCleanUp as $file) {
                 @unlink($file);
             }
         });
 
         return new FileCollection(...$results);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function isAvailable(): bool
-    {
-        return $this->canConvertSvg() || $this->canConvertWithImagick() || $this->concreteConverter->isAvailable();
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getAllowedMimeTypes(): array
-    {
-        $types = [];
-        $mime = new MimeTypes();
-        if ($this->canConvertSvg()) {
-            $types = array_merge($types, $mime->getMimeTypes('svg'));
-        }
-
-        if ($this->canConvertWithImagick()) {
-            $types = array_merge($types, $this->getAvailableImagickMimeTypes());
-        }
-
-        return array_unique(
-            array_merge(
-                $types,
-                $this->concreteConverter->getAllowedMimeTypes()
-            )
-        );
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function canConvertMimetype(string $mimetype): bool
-    {
-        $mimeTypes = $this->getAllowedMimeTypes();
-        return in_array($mimetype, $mimeTypes, true);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function wouldLikeSomeoneElseToConvertMimetype(string $mimetype): bool
-    {
-        return false;
     }
 }

--- a/app/Services/System/Http/UrlResolver.php
+++ b/app/Services/System/Http/UrlResolver.php
@@ -58,4 +58,45 @@ class UrlResolver
         $basePath = $basePath === '/' ? '' : $basePath; // Avoid double slashes
         return $baseUri . $basePath . '/' . $relativeUrl;
     }
+
+    /**
+     * Extract the origin (scheme + host + port) from a URL.
+     * 
+     * Example:
+     *   http://localhost:8000/asd/qwe?awe=123
+     * becomes:
+     *   http://localhost:8000
+     */
+    public static function baseUrl(string $url): string
+    {
+        $parts = parse_url($url);
+
+        if ($parts === false) {
+            throw InvalidBaseUrlException::forBaseUrl($url);
+        }
+
+        $hasScheme = isset($parts['scheme']);
+
+        if (!$hasScheme) {
+            // Fake a scheme and do not return it
+            $parts = parse_url('http://' . $url);
+
+            if ($parts === false) {
+                throw InvalidBaseUrlException::forBaseUrl($url);
+            }
+        }
+
+        if (empty($parts['host'])) {
+            throw InvalidBaseUrlException::forBaseUrl($url);
+        }
+
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+        if (!$hasScheme) {
+            return $host . $port;
+        }
+
+        return "{$parts['scheme']}://{$host}{$port}";
+    }
 }

--- a/config/file_converter.php
+++ b/config/file_converter.php
@@ -24,21 +24,27 @@ return [
         'rsvg_convert' => env('FILE_CONVERTER_BINARY_RSVG_CONVERT', 'rsvg-convert'),
         'image_magick'  => env('FILE_CONVERTER_BINARY_IMAGE_MAGICK', 'convert'),
     ],
-
+    /*
+    | When setting large timeouts make sure the infrastructure supports it and consider increasing
+    | server configurations default timeouts like nginx 60s defaults 
+    */ 
     'converters' => [
         'hawki_converter' => [
             'api_url' => env('HAWKI_FILE_CONVERTER_API_URL'),
             'api_key' => env('HAWKI_FILE_CONVERTER_API_KEY'),
-            'class' => HawkiDocConverter::class
+            'class' => HawkiDocConverter::class,
+            'timeout' => env('HAWKI_FILE_CONVERTER_TIMEOUT', 60),
         ],
         'gwdg_docling' =>[
             'api_url' => env('GWDG_FILE_CONVERTER_API_URL', 'https://chat-ai.academiccloud.de/v1/documents/convert'),
             'api_key' => env('GWDG_API_KEY'),
-            'class' => GwdgDoclingConverter::class
+            'class' => GwdgDoclingConverter::class,
+            'timeout' => env('GWDG_FILE_CONVERTER_TIMEOUT', 240),
         ],
         'kreuzberg' => [
             'api_url' => env('KREUZBERG_FILE_CONVERTER_API_URL'),
-            'class' => KreuzbergConverter::class
+            'class' => KreuzbergConverter::class,
+            'timeout' => env('KREUZBERG_FILE_CONVERTER_TIMEOUT', 60),
         ]
     ]
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     # or other file types. By using a dedicated container for this service, we can isolate its dependencies and resource usage from the main application,
     # ensuring better performance and scalability.
     file-converter:
-        image: digitalenvironments/hawki-toolkit-file-converter:2.0.0
+        image: digitalenvironments/hawki-toolkit-file-converter:3.0.0
         container_name: ${PROJECT_NAME}-file-converter
         restart: always
         environment:

--- a/tests/Unit/Console/Commands/FileStorageConverterTypesListTest.php
+++ b/tests/Unit/Console/Commands/FileStorageConverterTypesListTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Console\Commands\FileStorageConverterTypesList;
+use App\Services\FileConverter\Interfaces\FileConverterInterface;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tests\TestCase;
+use Tests\Unit\Console\Commands\Fixtures\FakeBackendConverter;
+use Tests\Unit\Console\Commands\Fixtures\FakeWrappingConverter;
+
+#[CoversClass(FileStorageConverterTypesList::class)]
+class FileStorageConverterTypesListTest extends TestCase
+{
+    // =========================================================================
+    // Availability guard
+    // =========================================================================
+
+    public function testItPrintsNothingWhenTheConverterIsUnavailable(): void
+    {
+        $this->bind(new FakeBackendConverter(mimeTypes: ['application/pdf'], available: false));
+
+        $blocks = $this->parseBlocks($this->runCommand());
+
+        self::assertSame([], $blocks);
+    }
+
+    // =========================================================================
+    // Bare (non-decorating) converter
+    // =========================================================================
+
+    public function testItPrintsASingleBlockForABareNonExtensionConverter(): void
+    {
+        $this->bind(new FakeBackendConverter(mimeTypes: ['image/png', 'application/pdf']));
+
+        $blocks = $this->parseBlocks($this->runCommand());
+
+        self::assertCount(1, $blocks);
+        self::assertSame(FakeBackendConverter::class, $blocks[0]['header']);
+        // Types are sorted alphabetically by the command.
+        self::assertSame(['application/pdf', 'image/png'], $blocks[0]['values']);
+    }
+
+    // =========================================================================
+    // Per-layer diff (core invariant)
+    // =========================================================================
+
+    public function testItPrintsAPerLayerDiffInnermostFirst(): void
+    {
+        $backend = new FakeBackendConverter(mimeTypes: ['application/pdf']);
+        $this->bind(new FakeWrappingConverter(
+            inner: $backend,
+            ownMimeTypes: ['image/tiff', 'image/svg+xml'],
+        ));
+
+        $blocks = $this->parseBlocks($this->runCommand());
+
+        self::assertCount(2, $blocks);
+
+        // Innermost converter is printed first.
+        self::assertSame(FakeBackendConverter::class, $blocks[0]['header']);
+        self::assertSame(FakeWrappingConverter::class, $blocks[1]['header']);
+
+        // Backend contributes its own type.
+        self::assertSame(['application/pdf'], $blocks[0]['values']);
+
+        // The wrapper contributes only its additions (sorted), and never
+        // re-lists a type already contributed by the inner converter.
+        self::assertSame(['image/svg+xml', 'image/tiff'], $blocks[1]['values']);
+        self::assertNotContains('application/pdf', $blocks[1]['values']);
+    }
+
+    public function testItHandlesAThreeLevelChain(): void
+    {
+        $backend = new FakeBackendConverter(mimeTypes: ['application/pdf']);
+        $middle = new FakeWrappingConverter(inner: $backend, ownMimeTypes: ['image/png']);
+        $outer = new FakeWrappingConverter(inner: $middle, ownMimeTypes: ['image/svg+xml']);
+        $this->bind($outer);
+
+        $blocks = $this->parseBlocks($this->runCommand());
+
+        self::assertCount(3, $blocks);
+        self::assertSame(FakeBackendConverter::class, $blocks[0]['header']);
+        self::assertSame(FakeWrappingConverter::class, $blocks[1]['header']);
+        self::assertSame(FakeWrappingConverter::class, $blocks[2]['header']);
+
+        self::assertSame(['application/pdf'], $blocks[0]['values']);
+        self::assertSame(['image/png'], $blocks[1]['values']);
+        self::assertSame(['image/svg+xml'], $blocks[2]['values']);
+    }
+
+    public function testItShowsTheNoAddedTypesMessageForALayerThatAddsNothing(): void
+    {
+        $backend = new FakeBackendConverter(mimeTypes: ['application/pdf', 'image/png']);
+        $this->bind(new FakeWrappingConverter(
+            inner: $backend,
+            ownMimeTypes: ['application/pdf'], // subset of the inner's types -> adds nothing
+        ));
+
+        $blocks = $this->parseBlocks($this->runCommand());
+
+        self::assertCount(2, $blocks);
+        self::assertSame(['application/pdf', 'image/png'], $blocks[0]['values']);
+        self::assertSame(['(No added types)'], $blocks[1]['values']);
+    }
+
+    // =========================================================================
+    // --extensions option
+    // =========================================================================
+
+    public function testItConvertsMimeTypesToExtensionsWithTheExtensionsFlag(): void
+    {
+        $this->bind(new FakeBackendConverter(mimeTypes: ['application/pdf']));
+
+        $blocks = $this->parseBlocks($this->runCommand(['--extensions' => true]));
+
+        self::assertCount(1, $blocks);
+        self::assertSame(['pdf'], $blocks[0]['values']);
+        self::assertNotContains('application/pdf', $blocks[0]['values']);
+    }
+
+    private function bind(FileConverterInterface $converter): void
+    {
+        $this->app->bind(FileConverterInterface::class, static fn () => $converter);
+    }
+
+    private function runCommand(array $arguments = []): string
+    {
+        Artisan::call('filestorage:converter:types:list', $arguments);
+
+        return Artisan::output();
+    }
+
+    /**
+     * Parses command output into ordered blocks. A block header is any line
+     * ending with ':'; subsequent indented lines are the block's values.
+     *
+     * @return list<array{header: string, values: list<string>}>
+     */
+    private function parseBlocks(string $output): array
+    {
+        $blocks = [];
+        $current = null;
+
+        foreach (preg_split('/\r?\n/', $output) as $line) {
+            $line = trim($line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            if (str_ends_with($line, ':')) {
+                if (null !== $current) {
+                    $blocks[] = $current;
+                }
+
+                $current = ['header' => mb_substr($line, 0, -1), 'values' => []];
+            } elseif (null !== $current) {
+                $current['values'][] = $line;
+            }
+        }
+
+        if (null !== $current) {
+            $blocks[] = $current;
+        }
+
+        return $blocks;
+    }
+}

--- a/tests/Unit/Console/Commands/Fixtures/FakeBackendConverter.php
+++ b/tests/Unit/Console/Commands/Fixtures/FakeBackendConverter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Commands\Fixtures;
+
+use App\Services\FileConverter\Interfaces\FileConverterInterface;
+use App\Services\Storage\Values\FileCollection;
+use App\Services\Storage\Values\FileReference;
+
+/**
+ * Minimal non-decorating converter used to simulate a concrete backend
+ * (e.g. KreuzbergConverter) in command tests. Its MIME types, availability,
+ * and class FQCN are fully controllable.
+ */
+class FakeBackendConverter implements FileConverterInterface
+{
+    public function __construct(
+        private readonly array $mimeTypes = [],
+        private readonly bool $available = true,
+    ) {
+    }
+
+    public static function isValidConfig(array $config): bool
+    {
+        return true;
+    }
+
+    public function setConfig(array $config): void
+    {
+    }
+
+    public function convert(FileReference $file): FileCollection
+    {
+        return new FileCollection();
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->available;
+    }
+
+    public function getAllowedMimeTypes(): array
+    {
+        return $this->mimeTypes;
+    }
+
+    public function canConvertMimetype(string $mimetype): bool
+    {
+        return \in_array($mimetype, $this->mimeTypes, true);
+    }
+
+    public function wouldLikeSomeoneElseToConvertMimetype(string $mimetype): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Console/Commands/Fixtures/FakeWrappingConverter.php
+++ b/tests/Unit/Console/Commands/Fixtures/FakeWrappingConverter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Console\Commands\Fixtures;
+
+use App\Services\FileConverter\Interfaces\FileConverterExtensionInterface;
+use App\Services\FileConverter\Interfaces\FileConverterInterface;
+use App\Services\Storage\Values\FileCollection;
+use App\Services\Storage\Values\FileReference;
+
+/**
+ * Decorating converter used in command tests. Implements the real
+ * {@see FileConverterExtensionInterface} so the command's chain walker
+ * descends into it. Its reported MIME types mirror a real decorator:
+ * the union of its own contributions and the inner converter's types.
+ */
+class FakeWrappingConverter implements FileConverterExtensionInterface
+{
+    public function __construct(
+        private readonly FileConverterInterface $inner,
+        private readonly array $ownMimeTypes = [],
+        private readonly bool $available = true,
+    ) {
+    }
+
+    public function getInnerConverter(): FileConverterInterface
+    {
+        return $this->inner;
+    }
+
+    public static function isValidConfig(array $config): bool
+    {
+        return true;
+    }
+
+    public function setConfig(array $config): void
+    {
+    }
+
+    public function convert(FileReference $file): FileCollection
+    {
+        return new FileCollection();
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->available;
+    }
+
+    public function getAllowedMimeTypes(): array
+    {
+        return array_values(array_unique(array_merge(
+            $this->ownMimeTypes,
+            $this->inner->getAllowedMimeTypes(),
+        )));
+    }
+
+    public function canConvertMimetype(string $mimetype): bool
+    {
+        return \in_array($mimetype, $this->getAllowedMimeTypes(), true);
+    }
+
+    public function wouldLikeSomeoneElseToConvertMimetype(string $mimetype): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Services/FileConverter/Handlers/AbstractFileConverterTest.php
+++ b/tests/Unit/Services/FileConverter/Handlers/AbstractFileConverterTest.php
@@ -67,4 +67,39 @@ class AbstractFileConverterTest extends TestCase
         static::assertFalse($sut->wouldLikeSomeoneElseToConvertMimetype('image/svg+xml'));
         static::assertFalse($sut->wouldLikeSomeoneElseToConvertMimetype(''));
     }
+
+    // =========================================================================
+    // getRequestTimeout
+    // =========================================================================
+
+    public function testItGetRequestTimeoutUsesDefaultWhenConfigHasNoTimeout(): void
+    {
+        $sut = new ConcreteFileConverterStub();
+        $sut->setConfig(['api_url' => 'http://example.com']);
+
+        static::assertSame(60, $sut->exposeRequestTimeout());
+    }
+
+    public function testItGetRequestTimeoutUsesDefaultWhenConfigNeverSet(): void
+    {
+        $sut = new ConcreteFileConverterStub();
+
+        static::assertSame(60, $sut->exposeRequestTimeout());
+    }
+
+    public function testItGetRequestTimeoutUsesConfiguredTimeoutWhenSet(): void
+    {
+        $sut = new ConcreteFileConverterStub();
+        $sut->setConfig(['api_url' => 'http://example.com', 'timeout' => 12]);
+
+        static::assertSame(12, $sut->exposeRequestTimeout());
+    }
+
+    public function testItGetRequestTimeoutCastsNonIntConfigValueToInt(): void
+    {
+        $sut = new ConcreteFileConverterStub();
+        $sut->setConfig(['timeout' => '120']);
+
+        static::assertSame(120, $sut->exposeRequestTimeout());
+    }
 }

--- a/tests/Unit/Services/FileConverter/Handlers/AbstractFileConverterTestFixtures/ConcreteFileConverterStub.php
+++ b/tests/Unit/Services/FileConverter/Handlers/AbstractFileConverterTestFixtures/ConcreteFileConverterStub.php
@@ -35,4 +35,12 @@ class ConcreteFileConverterStub extends AbstractFileConverter
     {
         return $this->mimeTypes;
     }
+
+    /**
+     * Exposes the protected {@see AbstractFileConverter::getRequestTimeout()} for testing.
+     */
+    public function exposeRequestTimeout(): int
+    {
+        return $this->getRequestTimeout();
+    }
 }

--- a/tests/Unit/Services/FileConverter/Handlers/HawkiDocConverterTest.php
+++ b/tests/Unit/Services/FileConverter/Handlers/HawkiDocConverterTest.php
@@ -6,9 +6,11 @@ namespace Tests\Unit\Services\FileConverter\Handlers;
 use App\Services\FileConverter\Exception\ConversionFailedException;
 use App\Services\FileConverter\Handlers\HawkiDocConverter;
 use App\Services\Storage\Values\FileReference;
+use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCase;
 use ZipArchive;
 
@@ -22,11 +24,22 @@ class HawkiDocConverterTest extends TestCase
     // Helpers
     // =========================================================================
 
-    private function makeSut(): HawkiDocConverter
+    private function makeSut(?Repository $cache = null): HawkiDocConverter
     {
-        $sut = new HawkiDocConverter();
+        $sut = new HawkiDocConverter($cache ?? $this->makeCache());
         $sut->setConfig(['api_url' => self::API_URL, 'api_key' => self::API_KEY]);
         return $sut;
+    }
+
+    /** @return MockObject&Repository */
+    private function makeCache(mixed $returnValue = null): MockObject
+    {
+        $cache = $this->createMock(Repository::class);
+        $cache->method('remember')
+            ->willReturnCallback(function ($key, $ttl, $callback) use ($returnValue) {
+                return $returnValue ?? $callback();
+            });
+        return $cache;
     }
 
     /**
@@ -56,7 +69,7 @@ class HawkiDocConverterTest extends TestCase
 
     public function testItConstructs(): void
     {
-        static::assertInstanceOf(HawkiDocConverter::class, new HawkiDocConverter());
+        static::assertInstanceOf(HawkiDocConverter::class, new HawkiDocConverter($this->makeCache()));
     }
 
     // =========================================================================
@@ -94,6 +107,12 @@ class HawkiDocConverterTest extends TestCase
 
     public function testItGetAllowedMimeTypesReturnsPdfAndDocTypes(): void
     {
+        Http::fake([
+            'http://hawki-converter.test' => Http::response([
+                'supported_formats' => ['pdf', 'doc', 'docx'],
+            ], 200),
+        ]);
+
         $types = $this->makeSut()->getAllowedMimeTypes();
 
         static::assertIsArray($types);

--- a/tests/Unit/Services/System/Http/UrlResolverTest.php
+++ b/tests/Unit/Services/System/Http/UrlResolverTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+use function PHPUnit\Framework\assertSame;
+
 #[CoversClass(UrlResolver::class)]
 class UrlResolverTest extends TestCase
 {
@@ -99,5 +101,27 @@ class UrlResolverTest extends TestCase
         $result = UrlResolver::resolve('invalid-base', 'https://example.com/page.html');
 
         static::assertSame('https://example.com/page.html', $result);
+    }
+
+    public static function urlsToReturnBase(): iterable
+    {
+        yield [
+            'http://example.com/page',
+            'http://example.com'
+        ];
+                yield [
+            'example.com/page',
+            'example.com'
+        ];
+        yield [
+            'http://example.com/page/nested/with?=123&swe',
+            'http://example.com'
+        ];
+    }
+
+    #[DataProvider('urlsToReturnBase')]
+    public function testItCreatesBAse(string $givenUrl, string $expectedBase): void
+    {
+        static::assertSame($expectedBase, UrlResolver::baseUrl($givenUrl));
     }
 }


### PR DESCRIPTION
- Use fileconverter 3.0.0 release https://github.com/hawk-digital-environments/hawki-toolkit-file-converter/
- Reuse and refactor synchronous file converter interface ( Use cache concepts from KreuzbergConverter for service metadata)
- Unify timeout and use nginx (60s) defaults as default timeouts ( but keep GWDG as before at 240 for existing custom setups/installs)

Ref: [HKI 160](https://digital-environments.atlassian.net/browse/HKI-160)