### PR TITLE
feat: implement non-streaming request handling for group chat export

### DIFF
--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -342,6 +342,9 @@ class StreamController extends Controller
         }
 
         // Record usage
+        // The "private" here is crap. Because this may not be a private request, but for example a group chat export.
+        // However, I would have to pass a lot of additional data to resolve this properly.
+        // For now this is fine and in the future we should generally clean up the token tracking.
         $this->usageAnalyzer->submitUsageRecord($agent->getUsage(), 'private');
 
         return ['success' => true, 'content' => json_encode(['text' => $res->text], JSON_THROW_ON_ERROR)];

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -2,14 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Services\Chat\Events\RoomAiWritingEndedEvent;
-use App\Services\Chat\Events\RoomAiWritingStartedEvent;
 use App\Events\RoomMessageEvent;
 use App\Jobs\SendMessage;
 use App\Models\Ai\AiModel;
 use App\Models\Room;
 use App\Services\Ai\AiService;
 use App\Services\Ai\UsageAnalyzerService;
+use App\Services\Chat\Events\RoomAiWritingEndedEvent;
+use App\Services\Chat\Events\RoomAiWritingStartedEvent;
 use App\Services\Chat\Message\Handlers\GroupMessageHandler;
 use App\Services\ExternalContent\CitationUrlCleaner;
 use App\Services\Storage\AvatarStorageService;
@@ -158,6 +158,10 @@ class StreamController extends Controller
             });
 
             return response()->json(['success' => true]);
+        }
+
+        if ($validatedData['payload']['stream'] === false) {
+            return response()->json($this->handleNonStreamingRequest($validatedData));
         }
 
         try {
@@ -315,6 +319,32 @@ class StreamController extends Controller
         }
 
         $this->usageAnalyzer->submitUsageRecord($agent->getUsage(), 'private');
+    }
+
+    /**
+     * Handle a non-streaming request that is not part of a group chat.
+     * This is used for the "export" feature, or any other feature that requires a single response from the AI agent without streaming.
+     */
+    private function handleNonStreamingRequest(array $validatedData): array
+    {
+        try {
+            $agent = $this->aiService->getAgent($validatedData);
+            $res = $agent->send();
+        } catch (RequestException $e) {
+            $this->logger->error('RequestException while sending request to agent', [
+                'exception' => $e,
+                'response' => $e->response->body()
+            ]);
+            return ['success' => false, 'error' => 'There was an error while sending your request to the AI agent. Please try again later.'];
+        } catch (\Throwable $e) {
+            $this->logger->error('Unexpected error while sending request to agent', ['exception' => $e]);
+            return ['success' => false, 'error' => 'There was an unexpected error while processing your request. Please try again later.'];
+        }
+
+        // Record usage
+        $this->usageAnalyzer->submitUsageRecord($agent->getUsage(), 'private');
+
+        return ['success' => true, 'content' => json_encode(['text' => $res->text], JSON_THROW_ON_ERROR)];
     }
 
     /**

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -347,7 +347,15 @@ class StreamController extends Controller
         // For now this is fine and in the future we should generally clean up the token tracking.
         $this->usageAnalyzer->submitUsageRecord($agent->getUsage(), 'private');
 
-        return ['success' => true, 'content' => json_encode(['text' => $res->text], JSON_THROW_ON_ERROR)];
+        try {
+            return ['success' => true, 'content' => json_encode(['text' => $res->text], JSON_THROW_ON_ERROR)];
+        } catch (\Throwable $e) {
+            $this->logger->error('Error encoding message data to JSON', [
+                'exception' => $e
+            ]);
+
+            return ['success' => false, 'error' => 'There was an error while processing the AI agent response. Please try again later.'];
+        }
     }
 
     /**

--- a/resources/js/components/ui/toast/Toaster.svelte
+++ b/resources/js/components/ui/toast/Toaster.svelte
@@ -162,7 +162,7 @@
         padding: var(--space-3, 0.75rem) var(--space-3, 0.75rem);
         border-radius: var(--corner-md);
         border: none;
-        background-color: color-mix(in oklch, var(--toast-color) 12%, var(--color-surface-raised));
+        background-color: color-mix(var(--toast-color) 20%, var(--color-surface-raised));
         color: var(--color-text);
         font-size: 0.875rem;
         pointer-events: auto;


### PR DESCRIPTION
I did not implement a non-streaming endpoint, and was not aware that the frontend needed it. 
The broken export for the groupchat was caused by that missing feature (it could not handle the stream provided by the backend)