### PR TITLE
fix: set default error message for non-improvable prompts

### DIFF
--- a/public/js/stream_functions.js
+++ b/public/js/stream_functions.js
@@ -294,7 +294,9 @@ which will be shown directly to the user. If the message is already good, just r
         }
         // If the model failed, we will show the user and return the original message so that the user can try again.
         if (done && result.includes('[NOT_IMPROVED]')) {
-            window.oldUiBridge.triggerSendToast(result.replace('[NOT_IMPROVED]', '').trim(), 'error');
+            window.oldUiBridge.triggerSendToast(window.__('chat.composer.actions.improvementModelSaidNoError'), 'error');
+            // Give ourselves a bit more logging context if someone complains in the future.
+            console.warn('Prompt improvement model said no: ', result);
             result = message;
         }
     };

--- a/resources/language/chat_de_DE.json
+++ b/resources/language/chat_de_DE.json
@@ -161,6 +161,7 @@
                 "cancelEdit": "Bearbeitung abbrechen",
                 "cancelResponse": "KI-Antwort abbrechen",
                 "improvementError": "Verbesserungsvorschläge konnten nicht geladen werden",
+                "improvementModelSaidNoError": "Deine Message ist gut. Keine Verbesserungsvorschläge verfügbar.",
                 "improveTooltip": "Verbessere deine Eingabe mit KI-gestützten Vorschlägen",
                 "cancelLabel": "Abbrechen"
             },

--- a/resources/language/chat_de_DE.json
+++ b/resources/language/chat_de_DE.json
@@ -161,7 +161,7 @@
                 "cancelEdit": "Bearbeitung abbrechen",
                 "cancelResponse": "KI-Antwort abbrechen",
                 "improvementError": "Verbesserungsvorschläge konnten nicht geladen werden",
-                "improvementModelSaidNoError": "Deine Message ist gut. Keine Verbesserungsvorschläge verfügbar.",
+                "improvementModelSaidNoError": "Deine Nachricht ist gut so. Keine Verbesserungsvorschläge verfügbar.",
                 "improveTooltip": "Verbessere deine Eingabe mit KI-gestützten Vorschlägen",
                 "cancelLabel": "Abbrechen"
             },

--- a/resources/language/chat_en_US.json
+++ b/resources/language/chat_en_US.json
@@ -161,6 +161,7 @@
                 "cancelEdit": "Cancel editing",
                 "cancelResponse": "Cancel AI response",
                 "improvementError": "Could not load improvement suggestions",
+                "improvementModelSaidNoError": "Your message is good as it is. No improvements suggested.",
                 "improveTooltip": "Improve your input with AI-powered suggestions",
                 "cancelLabel": "Cancel"
             },


### PR DESCRIPTION
Previously I let the model generate a error message, but because we use a really cheap model it responded crap... 
<img width="978" height="248" alt="image" src="https://github.com/user-attachments/assets/35aff288-837e-4a22-850f-4da3aaf41b18" />
Now it uses a static message instead.