### PR TITLE
fix: adjust position of SystemPromptDialog to ensure correct ordering…

### DIFF
--- a/resources/js/components/chat/composer/SettingsMenu.svelte
+++ b/resources/js/components/chat/composer/SettingsMenu.svelte
@@ -58,12 +58,6 @@
     }
 </script>
 
-<SystemPromptDialog
-    bind:open={systemPromptOpen}
-    value={composerContext.systemPrompt ?? ''}
-    onChange={(newPrompt) => { composerContext.systemPrompt = newPrompt; }}
-/>
-
 {#snippet settingsBody()}
     <div class="settings-body">
         <div class="system-prompt-section">
@@ -186,6 +180,12 @@
         </Popover>
     {/snippet}
 </Breakpoint>
+
+<SystemPromptDialog
+    bind:open={systemPromptOpen}
+    value={composerContext.systemPrompt ?? ''}
+    onChange={(newPrompt) => { composerContext.systemPrompt = newPrompt; }}
+/>
 
 <style>
 


### PR DESCRIPTION
Moving the prompt component to the bottom, it will be "higher" in the stack, 
fixing this issue:
<img width="1776" height="1350" alt="image" src="https://github.com/user-attachments/assets/e0cb56e0-1647-4a9b-bf22-5f63b8ef2c44" />
