### PR TITLE
fix: focus back into input box after file picker actions

### DIFF
--- a/resources/js/components/chat/composer/FilePicker.svelte
+++ b/resources/js/components/chat/composer/FilePicker.svelte
@@ -30,10 +30,12 @@
             target.value = '';
         }
         isAdding = false;
+        composerContext.focusInput();
     }
 
     function handleCancel() {
         isAdding = false;
+        composerContext.focusInput();
     }
 </script>
 


### PR DESCRIPTION
Basically, if you upload a file or cancel the upload,
the focus jumps back into the input field.
Fixing:
<img width="2404" height="512" alt="image" src="https://github.com/user-attachments/assets/78ada352-167d-41e2-bc2a-070c892f273d" />
