### PR TITLE
Fix/rename unloaded legacy chat

### DIFF
--- a/public/js/groupchat_functions.js
+++ b/public/js/groupchat_functions.js
@@ -61,8 +61,11 @@ function initializeGroupChatModule(roomsData) {
     });
     window.oldUiBridge.onRenameChat(async (slug, newName) => {
         const formData = new FormData();
-        if (chatName) formData.append('name', chatName);
-        updateRoomInfo(activeRoom.slug, formData);
+        if (newName) formData.append('name', newName);
+        updateRoomInfo(slug, formData);
+        if (window.oldUiMessageHistory.conversationSlug === slug) {
+            window.oldUiMessageHistory.updateConversation({name: newName});
+        }
     });
     window.oldUiBridge.onOpenRoomControlPanel((slug) => {
         openRoomCP(slug);

--- a/resources/js/oldUi/OldUiMessageHistory.svelte.ts
+++ b/resources/js/oldUi/OldUiMessageHistory.svelte.ts
@@ -8,14 +8,12 @@ export class OldUiMessageHistory {
     private sync = new SyncPipeline<{ [LOAD_CONVERSATION_EVENT]: OldUiConversation }>();
 
     private _type: ComposerContextType = $state('room');
-    private _conversation: OldUiConversation | null = null;
+    private _conversation = $state<OldUiConversation | null>(null);
     private _systemPrompt = $state('');
-    private _conversationName = $state('');
-    private _conversationSlug = $state('');
     private _isInConversation = $state(false);
 
-    public readonly conversationName = $derived.by(() => this._conversationName);
-    public readonly conversationSlug = $derived.by(() => this._conversationSlug);
+    public readonly conversationName = $derived.by(() => this._conversation?.name ?? '');
+    public readonly conversationSlug = $derived.by(() => this._conversation?.slug ?? '');
     public readonly isInConversation = $derived.by(() => this._isInConversation);
     public readonly systemPrompt = $derived.by(() => this._systemPrompt);
     public readonly canAdministrate = $derived.by(() => this._conversation?.role === 'admin' || this._type === 'aiConv');
@@ -42,12 +40,6 @@ export class OldUiMessageHistory {
             update = {...update, messages: update.messages.map(m => this.legacyFixMessageContent(m))};
         }
         this._conversation = {...this._conversation, ...update};
-        if (update.name !== undefined) {
-            this._conversationName = update.name;
-        }
-        if (update.slug !== undefined) {
-            this._conversationSlug = update.slug;
-        }
         if (update.system_prompt !== undefined) {
             this._systemPrompt = update.system_prompt;
         }
@@ -55,8 +47,6 @@ export class OldUiMessageHistory {
 
     public clearConversation(): void {
         this._conversation = null;
-        this._conversationName = '';
-        this._conversationSlug = '';
         this._systemPrompt = '';
         this._isInConversation = false;
     }

--- a/resources/js/snippets/ChatSidebarButton.svelte
+++ b/resources/js/snippets/ChatSidebarButton.svelte
@@ -3,7 +3,6 @@ However, as we want to merge them both anyway, it's not worth the effort to spli
 <script lang="ts">
     import type {ComposerContextType} from '$lib/components/chat/composer/contexts/ComposerContext.svelte.js';
     import {oldUiBridge} from '$lib/oldUi/OldUiBridge.svelte.js';
-    import {oldUiMessageHistory} from '$lib/oldUi/OldUiMessageHistory.svelte.js';
     import type {HTMLSvelteSnippetElement} from '$lib/svelteSnippetLoader.js';
     import RoomNameMenu from '$lib/components/chat/nameMenu/RoomNameMenu.svelte';
     import AiConvNameMenu from '$lib/components/chat/nameMenu/AiConvNameMenu.svelte';
@@ -36,11 +35,11 @@ However, as we want to merge them both anyway, it's not worth the effort to spli
     let isRenaming = $state(false);
 
     $effect(() => {
-        if (slug && oldUiMessageHistory.conversationSlug === slug) {
-            if (name !== oldUiMessageHistory.conversationName) {
-                root.setProps({name: oldUiMessageHistory.conversationName});
+        return oldUiBridge.onRenameChat((renamedSlug, newName) => {
+            if (slug && renamedSlug === slug) {
+                root.setProps({name: newName});
             }
-        }
+        });
     });
 
     const sharedProps: ComponentProps<typeof RoomNameMenu | typeof AiConvNameMenu> = $derived.by(() => ({


### PR DESCRIPTION
This pull request refactors how conversation name and slug are managed in the `OldUiMessageHistory` class and updates related logic in the chat sidebar button component. The main goal is to simplify state management by deriving the conversation name and slug directly from the conversation object, reducing duplicated state and potential for inconsistencies.

### State management simplification

* Refactored `OldUiMessageHistory` to derive `conversationName` and `conversationSlug` directly from the `_conversation` object, removing separate state variables for these properties. This reduces redundancy and ensures these properties always reflect the current conversation state. [[1]](diffhunk://#diff-5cfe1f7d88ef05c617d3173e04f1cb022f3d0057d412d9bee26d0b9fa5535abcL11-R16) [[2]](diffhunk://#diff-5cfe1f7d88ef05c617d3173e04f1cb022f3d0057d412d9bee26d0b9fa5535abcL45-L59)

### Component logic updates

* Updated `ChatSidebarButton.svelte` to remove the direct dependency on `oldUiMessageHistory` for conversation name and slug, and instead handle chat renames through the `oldUiBridge.onRenameChat` event. This ensures UI updates are consistent with the new state management approach. [[1]](diffhunk://#diff-dd87aeaeba5cca9070dfdd06b94aab45eb1df8c7c3058a27c180e2f502bc9e03L6) [[2]](diffhunk://#diff-dd87aeaeba5cca9070dfdd06b94aab45eb1df8c7c3058a27c180e2f502bc9e03L39-R43)

Fixes: https://discord.com/channels/1314572179798753363/1526167458438844466/1526170597946822716