### PR TITLE
Improve keyboard accessibility for composer UI

### DIFF
--- a/resources/js/components/chat/composer/FileChips.svelte
+++ b/resources/js/components/chat/composer/FileChips.svelte
@@ -13,8 +13,100 @@
     import {__} from '$lib/utils/translator.js';
     import Alert02Icon from '$lib/components/ui/icons/iconset/Alert02Icon.svelte';
     import Cancel01Icon from '$lib/components/ui/icons/iconset/Cancel01Icon.svelte';
+    import {tick} from 'svelte';
 
     const composerContext = useComposerContext();
+
+    let chipsEl = $state(null as HTMLDivElement | null);
+
+    // Roving tabindex, matching the conflict picker: the chip row is a single tab
+    // stop, arrow keys move between the chips inside it.
+    let activeIndex = $state(0);
+
+    // Keep the roving index in range when chips are added or removed.
+    $effect(() => {
+        if (activeIndex > composerContext.attachments.list.length - 1) {
+            activeIndex = 0;
+        }
+    });
+
+    function chipButtons(): HTMLElement[] {
+        return chipsEl ? Array.from(chipsEl.querySelectorAll<HTMLElement>('[data-file-chip]')) : [];
+    }
+
+    function focusChip(index: number) {
+        const chip = chipButtons()[index];
+        if (!chip) return;
+        activeIndex = index;
+        chip.focus();
+    }
+
+    /**
+     * Removes a chip and lands focus somewhere sensible: the chip that slid into the
+     * removed slot, otherwise the preceding one, otherwise the textarea once the row
+     * is empty. Without this, focus falls back to `<body>` and keyboard users have to
+     * tab in from the top of the page again.
+     */
+    async function removeAndMoveFocus(file: File, index: number) {
+        composerContext.attachments.remove(file);
+        // tick() flushes the re-render; the extra frame lets the removed chip's
+        // (zero-duration) out-transition finish so it is out of the DOM before we
+        // pick the chip to focus by index.
+        await tick();
+        await new Promise(requestAnimationFrame);
+
+        if (!composerContext.attachments.hasAny) {
+            composerContext.focusInput();
+            return;
+        }
+
+        const chips = chipButtons();
+        if (chips.length === 0) {
+            composerContext.focusInput();
+            return;
+        }
+        focusChip(Math.min(index, chips.length - 1));
+    }
+
+    // Enter/Space is handled here rather than through the button's click handler so
+    // keyboard removal can move focus onward while a mouse click returns to the textarea.
+    // preventDefault stops the browser from firing a synthetic click afterwards.
+    function onChipKeydown(event: KeyboardEvent, file: File, index: number) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            void removeAndMoveFocus(file, index);
+            return;
+        }
+
+        const last = composerContext.attachments.list.length - 1;
+        let target: number | null = null;
+
+        switch (event.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+                target = Math.min(index + 1, last);
+                break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                target = Math.max(index - 1, 0);
+                break;
+            case 'Home':
+                target = 0;
+                break;
+            case 'End':
+                target = last;
+                break;
+        }
+
+        if (target === null) return;
+        event.preventDefault();
+        focusChip(target);
+    }
+
+    function onChipClick(file: File) {
+        composerContext.attachments.remove(file);
+        composerContext.focusInput();
+    }
 
     // The issue is either that we can not upload files at all,
     // or if we want to upload an image, that the model does not support vision.
@@ -36,7 +128,13 @@
 </script>
 
 {#if composerContext.attachments.hasAny}
-    <div class="file-chips" class:file-chips--no-conflict={!currentModelHasFileIssue}>
+    <div
+        class="file-chips"
+        class:file-chips--no-conflict={!currentModelHasFileIssue}
+        role="group"
+        aria-label={__('chat.composer.fileChips.listAriaLabel')}
+        bind:this={chipsEl}
+    >
         {#each composerContext.attachments.list as file, i (`${file.name}-${i}`)}
             {@const conflict = currentModelHasFileIssue}
             <span class="file-chip-mask" out:maskSlideDown|global style:--file-chip-delay={`${Math.min(i, 4) * 35}ms`}>
@@ -56,8 +154,12 @@
                                         hasIssue ? 'file-chip--conflict' : 'file-chip--default'
                                     ],
                                     title: issueMessage,
-                                    onclick: () => composerContext.attachments.remove(file),
-                                    'aria-label': `${file.name} entfernen`
+                                    onclick: () => onChipClick(file),
+                                    onkeydown: (event: KeyboardEvent) => onChipKeydown(event, file, i),
+                                    onfocus: () => activeIndex = i,
+                                    tabindex: i === activeIndex ? 0 : -1,
+                                    'data-file-chip': '',
+                                    'aria-label': __('chat.composer.fileChips.removeFileAriaLabel', {file: file.name})
                                 }
                             )}
                         >
@@ -111,6 +213,23 @@
         animation-delay: var(--file-chip-delay, 0ms);
     }
 
+    /* The chip's mask clips overflow for the slide animation, so the focus ring is
+       drawn inside the chip rather than around it. */
+    .file-chip:focus-visible {
+        outline: 1px solid var(--color-focus-ring);
+        outline-offset: -2px;
+        border-radius: var(--corner-sm);
+    }
+
+    .file-chip--default:focus-visible {
+        background-color: var(--color-hover);
+        color: var(--color-text);
+    }
+
+    .file-chip--conflict:focus-visible {
+        background-color: color-mix(in oklch, var(--color-error) 18%, transparent);
+    }
+
     .file-chip--default {
         background-color: var(--color-surface);
         color: var(--color-text-muted);
@@ -157,11 +276,13 @@
         color: color-mix(in oklch, var(--color-error) 70%, transparent);
     }
 
-    .file-chip--default:hover :global(.file-chip-remove) {
+    .file-chip--default:hover :global(.file-chip-remove),
+    .file-chip--default:focus-visible :global(.file-chip-remove) {
         color: var(--color-text);
     }
 
-    .file-chip--conflict:hover :global(.file-chip-remove) {
+    .file-chip--conflict:hover :global(.file-chip-remove),
+    .file-chip--conflict:focus-visible :global(.file-chip-remove) {
         color: var(--color-error);
     }
 

--- a/resources/js/components/chat/composer/ModelConflictPicker.svelte
+++ b/resources/js/components/chat/composer/ModelConflictPicker.svelte
@@ -22,6 +22,52 @@
                 .flatMap(issue => issue.missingTools ?? []);
         }
     );
+
+    // Roving tabindex: the card list is a single tab stop. Tab moves past the whole
+    // list to the next composer control; arrow keys move between the cards.
+    let listEl = $state(null as HTMLDivElement | null);
+    let activeIndex = $state(0);
+
+    // Keep the roving index in range when the list of usable models changes.
+    $effect(() => {
+        if (activeIndex > usableModels.length - 1) {
+            activeIndex = 0;
+        }
+    });
+
+    function focusCard(index: number) {
+        const cards = listEl?.querySelectorAll<HTMLElement>('[data-conflict-card]');
+        const card = cards?.[index];
+        if (!card) return;
+        activeIndex = index;
+        card.focus();
+    }
+
+    function onListKeydown(event: KeyboardEvent) {
+        const last = usableModels.length - 1;
+        let target: number | null = null;
+
+        switch (event.key) {
+            case 'ArrowRight':
+            case 'ArrowDown':
+                target = Math.min(activeIndex + 1, last);
+                break;
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                target = Math.max(activeIndex - 1, 0);
+                break;
+            case 'Home':
+                target = 0;
+                break;
+            case 'End':
+                target = last;
+                break;
+        }
+
+        if (target === null) return;
+        event.preventDefault();
+        focusCard(target);
+    }
 </script>
 
 {#if !composerContext.modelUsage.isValid && composerContext.guard.showsAiUiElements}
@@ -55,19 +101,28 @@
             <!-- Model list -->
             {#if usableModels.length > 0}
                 <!-- Scrollable model cards -->
-                <div class="conflict-models-scroll">
-                    {#each usableModels as m (m.id)}
+                <div
+                    class="conflict-models-scroll"
+                    role="group"
+                    aria-label={__('chat.composer.modelConflict.modelListAriaLabel')}
+                    bind:this={listEl}
+                    onkeydown={onListKeydown}
+                >
+                    {#each usableModels as m, i (m.id)}
                         <button
                             onclick={() => composerContext.model.set(m.id)}
+                            onfocus={() => activeIndex = i}
                             class="conflict-model-card"
+                            data-conflict-card
+                            tabindex={i === activeIndex ? 0 : -1}
                         >
                             <div class="conflict-card-top">
                                 <div class="conflict-provider-row">
-                                    <StatusDotForModel model={m}/>
+                                    <StatusDotForModel model={m} focusable={false}/>
                                     <span class="conflict-provider-name">{m.provider?.name}</span>
                                 </div>
                                 <div class="conflict-card-right">
-                                    <ModelDemandBars model={m}/>
+                                    <ModelDemandBars model={m} focusable={false}/>
                                 </div>
                             </div>
                             <span class="conflict-model-name">{m.label}</span>
@@ -107,7 +162,8 @@
         gap: calc(0.25rem * 2.5);
         padding-inline: var(--space-3, calc(0.25rem * 3));
         padding-top: var(--space-3, calc(0.25rem * 3));
-        padding-bottom: calc(0.25rem * 2.5);
+        /* Trimmed by the top padding the card scroller needs for its focus ring. */
+        padding-bottom: calc(0.25rem * 1.5);
     }
 
     .conflict-icon-wrapper {
@@ -151,6 +207,10 @@
         gap: calc(0.25rem * 2);
         overflow-x: auto;
         padding-inline: var(--space-3, calc(0.25rem * 3));
+        /* The top padding is what keeps the focus ring (1px outline + 2px offset) of
+           each card from being clipped by the scroll container and the panel's
+           `overflow: hidden`. Don't remove it without replacing the clearance. */
+        padding-top: var(--space-1, calc(0.25rem * 1));
         padding-bottom: var(--space-3, calc(0.25rem * 3));
         scrollbar-width: thin;
         scroll-snap-type: x mandatory;
@@ -184,6 +244,10 @@
 
         &:hover {
             box-shadow: var(--elevation-1);
+        }
+
+        &:focus-visible {
+            border-radius: var(--corner-sm);
         }
     }
 

--- a/resources/js/components/chat/composer/ModelDemandBars.svelte
+++ b/resources/js/components/chat/composer/ModelDemandBars.svelte
@@ -13,9 +13,11 @@
         model: AiModel;
         /** If true, the human-readable demand label will be shown next to the bars. */
         showLabel?: boolean;
+        /** Set to false when the bars sit inside another focusable control, so they do not add a tab stop. */
+        focusable?: boolean;
     }
 
-    const {model, showLabel}: Props = $props();
+    const {model, showLabel, focusable = true}: Props = $props();
 
     const demand = $derived.by(() => {
         if (model.demand === 'low' || model.demand === 'medium' || model.demand === 'high') {
@@ -40,7 +42,7 @@
     const bars = [0, 1, 2] as const;
 </script>
 
-<Tooltip tooltip={tooltip}>
+<Tooltip tooltip={tooltip} {focusable}>
     {#snippet children({props})}
         <span class="load-bars" aria-label={__('chat.composer.demandBars.ariaLabel', {label})} {...props}>
             {#each bars as i (i)}

--- a/resources/js/components/chat/composer/StatusDotForModel.svelte
+++ b/resources/js/components/chat/composer/StatusDotForModel.svelte
@@ -14,13 +14,16 @@
         size?: 'sm' | 'md';
         /** If true, the human-readable status label will be shown next to the dot. */
         showLabel?: boolean;
+        /** Set to false when the dot sits inside another focusable control, so it does not add a tab stop. */
+        focusable?: boolean;
     }
-    const {model, size, showLabel = false}: Props = $props();
+    const {model, size, showLabel = false, focusable = true}: Props = $props();
 </script>
 
 <StatusDot
     status={model.status}
     size={size}
+    {focusable}
     labelOnline={showLabel ? __('chat.composer.statusDot.onlineLabel') : undefined}
     tooltipOnline={__('chat.composer.statusDot.onlineTooltip')}
     labelUnknown={showLabel ? __('chat.composer.statusDot.unknownLabel') : undefined}

--- a/resources/js/components/ui/status-dot/StatusDot.svelte
+++ b/resources/js/components/ui/status-dot/StatusDot.svelte
@@ -25,6 +25,8 @@
         tooltipOffline?: Snippet | string;
         /** Tooltip content for the `'unknown'` status. Defaults to the translated string. */
         tooltipUnknown?: Snippet | string;
+        /** Set to false when the dot sits inside another focusable control, so it does not add a tab stop. */
+        focusable?: boolean;
     }
 
     const {
@@ -35,7 +37,8 @@
         labelUnknown,
         tooltipOnline = __('ui.statusDot.onlineTooltip'),
         tooltipOffline = __('ui.statusDot.offlineTooltip'),
-        tooltipUnknown = __('ui.statusDot.unknownTooltip')
+        tooltipUnknown = __('ui.statusDot.unknownTooltip'),
+        focusable = true
     }: Props = $props();
 
     const label = $derived.by(() => {
@@ -51,7 +54,7 @@
     });
 </script>
 
-<Tooltip tooltip={tooltip} delayDuration={300}>
+<Tooltip tooltip={tooltip} delayDuration={300} {focusable}>
     {#snippet children({props})}
         <div class="status-dot-wrapper status-dot-wrapper--{status}">
             <span

--- a/resources/js/components/ui/tooltip/Tooltip.svelte
+++ b/resources/js/components/ui/tooltip/Tooltip.svelte
@@ -25,6 +25,13 @@
         /** If true, the tooltip will not open on hover/focus. */
         disabled?: boolean;
         /**
+         * If false, the trigger is removed from the tab order. Use this for decorative
+         * tooltips nested inside another focusable control (a status dot inside a button,
+         * for example) — without it every such tooltip adds its own tab stop.
+         * The tooltip still opens on hover and on focus of the surrounding control.
+         */
+        focusable?: boolean;
+        /**
          * The content that triggers the tooltip, typically an icon or button. Can be a string or a Svelte snippet.
          * If a snippet is provided, it will receive a `props` object as an argument, which MUST be used to spread onto the root element of the snippet.
          * This ensures proper functionality of the tooltip trigger.
@@ -40,8 +47,17 @@
         sideOffset = 4,
         open = $bindable(false),
         disabled,
+        focusable = true,
         ...restProps
     }: Props = $props();
+
+    // bits-ui makes every trigger focusable. For decorative triggers inside another
+    // control that would add a redundant tab stop, so strip the tabindex it injects.
+    function applyFocusable(props: Record<string, any>): Record<string, any> {
+        if (focusable) return props;
+        const {tabindex, tabIndex, ...rest} = props;
+        return {...rest, tabindex: -1};
+    }
 
     const longPress = $state.raw({
         timer: null as ReturnType<typeof setTimeout> | null
@@ -83,7 +99,7 @@
         <TooltipPrimitive.Trigger>
             {#snippet child(a)}
                 <SnippetOrStringTrigger value={children as string|Snippet} snippetArgs={{
-                    props: mergeProps(
+                    props: applyFocusable(mergeProps(
                         a.props,
                         {
                             ontouchstart: handleTouchStart,
@@ -91,7 +107,7 @@
                             ontouchcancel: handleTouchEnd,
                             oncontextmenu: handleContextMenu
                         }
-                    )
+                    ))
                 }}/>
             {/snippet}
         </TooltipPrimitive.Trigger>

--- a/resources/language/chat_de_DE.json
+++ b/resources/language/chat_de_DE.json
@@ -125,6 +125,8 @@
             },
             "fileChips": {
                 "conflictMessage": "Vom aktuellen Modell nicht unterstützt",
+                "listAriaLabel": "Angehängte Dateien, mit den Pfeiltasten navigieren",
+                "removeFileAriaLabel": "Datei :file entfernen",
                 "uploadError": "Fehler beim Hochladen: :issue"
             },
             "fileDrop": {
@@ -139,7 +141,8 @@
                 "conflictTitleMultiple": ":model unterstützt die folgenden Anforderungen nicht",
                 "singleModelCapable": "Dieses Modell kann alles was du brauchst.",
                 "multipleModelsCapable": "Diese :count Modelle können alles was du brauchst.",
-                "noModelsAvailable": "Kein verfügbares Modell unterstützt diese Kombination. Entferne ein Tool oder einen Anhang."
+                "noModelsAvailable": "Kein verfügbares Modell unterstützt diese Kombination. Entferne ein Tool oder einen Anhang.",
+                "modelListAriaLabel": "Kompatible Modelle, mit den Pfeiltasten navigieren"
             },
             "toolMenuConfig": {
                 "variantLabel": "Variante",

--- a/resources/language/chat_en_US.json
+++ b/resources/language/chat_en_US.json
@@ -125,6 +125,8 @@
             },
             "fileChips": {
                 "conflictMessage": "Not supported by the current model",
+                "listAriaLabel": "Attached files, use the arrow keys to browse",
+                "removeFileAriaLabel": "Remove file :file",
                 "uploadError": "Upload error: :issue"
             },
             "fileDrop": {
@@ -139,7 +141,8 @@
                 "conflictTitleMultiple": ":model does not support the following requirements",
                 "singleModelCapable": "This model can do everything you need.",
                 "multipleModelsCapable": "These :count models can do everything you need.",
-                "noModelsAvailable": "No available model supports this combination. Remove a tool or an attachment."
+                "noModelsAvailable": "No available model supports this combination. Remove a tool or an attachment.",
+                "modelListAriaLabel": "Compatible models, use the arrow keys to browse"
             },
             "toolMenuConfig": {
                 "variantLabel": "Variant",


### PR DESCRIPTION
Add roving tabindex and keyboard navigation to file chips and model conflict picker, including proper focus movement when chips are removed. Introduce a focusable prop on Tooltip, StatusDot and ModelDemandBars to avoid redundant tab stops for decorative controls and pass it where nested. Add roles, aria-labels and data attributes for better screen-reader and DOM targeting. Update focus-visible styles and padding to avoid clipped focus rings. Update en/DE translations for new aria labels. These changes improve keyboard and screen-reader usability in the composer.