### PR TITLE
Extend python mimes for plain text treatment

### DIFF
--- a/app/Services/Storage/Values/PlainTextLanguageType.php
+++ b/app/Services/Storage/Values/PlainTextLanguageType.php
@@ -659,6 +659,9 @@ enum PlainTextLanguageType: string
         'text/x-python' => self::PYTHON,
         'text/x-python2' => self::PYTHON,
         'text/x-python3' => self::PYTHON,
+        'text/x-script.python' => self::PYTHON,
+        'application/x-python' => self::PYTHON,
+        'application/x-python-code' => self::PYTHON,
         // RB
         'application/x-ruby' => self::RB,
         'text/x-ruby' => self::RB,

--- a/app/Services/Storage/Values/PlainTextLanguageType.php
+++ b/app/Services/Storage/Values/PlainTextLanguageType.php
@@ -660,8 +660,6 @@ enum PlainTextLanguageType: string
         'text/x-python2' => self::PYTHON,
         'text/x-python3' => self::PYTHON,
         'text/x-script.python' => self::PYTHON,
-        'application/x-python' => self::PYTHON,
-        'application/x-python-code' => self::PYTHON,
         // RB
         'application/x-ruby' => self::RB,
         'text/x-ruby' => self::RB,

--- a/tests/Unit/Services/Storage/Values/PlainTextLanguageTypeTest.php
+++ b/tests/Unit/Services/Storage/Values/PlainTextLanguageTypeTest.php
@@ -65,8 +65,6 @@ class PlainTextLanguageTypeTest extends TestCase
         yield 'text/html' => ['text/html', PlainTextLanguageType::HTML];
         yield 'text/x-python' => ['text/x-python', PlainTextLanguageType::PYTHON];
         yield 'text/x-script.python' => ['text/x-script.python', PlainTextLanguageType::PYTHON];
-        yield 'application/x-python' => ['application/x-python', PlainTextLanguageType::PYTHON];
-        yield 'application/x-python-code' => ['application/x-python-code', PlainTextLanguageType::PYTHON];
         yield 'text/x-php' => ['text/x-php', PlainTextLanguageType::PHP];
         yield 'text/css' => ['text/css', PlainTextLanguageType::CSS];
         yield 'text/javascript' => ['text/javascript', PlainTextLanguageType::JS];

--- a/tests/Unit/Services/Storage/Values/PlainTextLanguageTypeTest.php
+++ b/tests/Unit/Services/Storage/Values/PlainTextLanguageTypeTest.php
@@ -64,6 +64,9 @@ class PlainTextLanguageTypeTest extends TestCase
         yield 'application/json' => ['application/json', PlainTextLanguageType::JSON];
         yield 'text/html' => ['text/html', PlainTextLanguageType::HTML];
         yield 'text/x-python' => ['text/x-python', PlainTextLanguageType::PYTHON];
+        yield 'text/x-script.python' => ['text/x-script.python', PlainTextLanguageType::PYTHON];
+        yield 'application/x-python' => ['application/x-python', PlainTextLanguageType::PYTHON];
+        yield 'application/x-python-code' => ['application/x-python-code', PlainTextLanguageType::PYTHON];
         yield 'text/x-php' => ['text/x-php', PlainTextLanguageType::PHP];
         yield 'text/css' => ['text/css', PlainTextLanguageType::CSS];
         yield 'text/javascript' => ['text/javascript', PlainTextLanguageType::JS];


### PR DESCRIPTION
I took a random file from a python github repo and it was `'text/x-script.python' => self::PYTHON,` ~> so add some more python mimes from files found in the wild