### PR TITLE
feat: Use latest major relase of hawki file converter by default

### DIFF
--- a/_changelog/next.md
+++ b/_changelog/next.md
@@ -3,6 +3,7 @@
 ### What's New
 
 - Updated the GWDG-hosted open-weight model catalog to match the current upstream lineup. **Added:** DeepSeek V4 Flash and Mistral Medium 3.5 128B. **Removed** (no longer served by GWDG): DeepSeek R1 Distill Llama 70B, InternVL 3.5 30B A3B, MedGemma 27B Instruct, Mistral Large 3 675B Instruct 2512, Qwen 3 Coder 30B A3B Instruct, and Teuken 7B Instruct Research. Administrators who pinned any of the removed models via `DEFAULT_MODEL`, `DEFAULT_FILEUPLOAD_MODEL`, or `MODELS_GWDG_*` env vars should update their configuration to use a current model ID.
+- Use the latest major release of the hawki file converter. The exact version is still available in the hawki file converters root response.
 
 ### Quality of Life
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     # or other file types. By using a dedicated container for this service, we can isolate its dependencies and resource usage from the main application,
     # ensuring better performance and scalability.
     file-converter:
-        image: digitalenvironments/hawki-toolkit-file-converter:3.0.1
+        image: digitalenvironments/hawki-toolkit-file-converter:3
         container_name: ${PROJECT_NAME}-file-converter
         restart: no
         environment:


### PR DESCRIPTION
Updates file converter.

Latest major release: https://github.com/hawk-digital-environments/hawki-toolkit-file-converter/actions/runs/30991781967