### PR TITLE
fix: update container retention policy version and adjust image names in deployment pipelines

### DIFF
--- a/.github/workflows/deploy-hawk-prod.yml
+++ b/.github/workflows/deploy-hawk-prod.yml
@@ -59,15 +59,14 @@ jobs:
 
   remove-old-images:
     permissions:
-      contents: write
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@v3.1.0
         with:
-          account: user
+          account: ${{github.repository_owner}}
           token: ${{secrets.GITHUB_TOKEN}}
-          image-names: "${{github.event.repository.name}}"
+          image-names: "hawki"
           image-tags: "prod-* !prod-latest"
           keep-n-most-recent: 5
           cut-off: 1h

--- a/.github/workflows/deploy-hawk-testing.yml
+++ b/.github/workflows/deploy-hawk-testing.yml
@@ -59,15 +59,14 @@ jobs:
 
   remove-old-images:
     permissions:
-      contents: write
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@v3.1.0
         with:
-          account: user
+          account: ${{github.repository_owner}}
           token: ${{secrets.GITHUB_TOKEN}}
-          image-names: "${{github.event.repository.name}}"
+          image-names: "hawki"
           image-tags: "testing-* !testing-latest"
           keep-n-most-recent: 5
           cut-off: 1h


### PR DESCRIPTION
This pull request updates the container image retention policy in the deployment workflows for both production and testing environments. The main changes are upgrading the action version, correcting the account and image name usage, and simplifying permissions.

This fixes the failing pipelines due to:
https://github.com/snok/container-retention-policy/issues/132
and
https://github.com/snok/container-retention-policy/issues/129