### PR TITLE
feat: enhance frontend migration command to support plugin selection

### DIFF
--- a/app/Console/Commands/Make/MakeFrontendMigrationCommand.php
+++ b/app/Console/Commands/Make/MakeFrontendMigrationCommand.php
@@ -1,73 +1,72 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands\Make;
 
 use App\Services\Frontend\Migrations\Make\FrontendMigrationCreator;
-use App\Services\Frontend\Migrations\Make\PluginMigrationHookEnsurer;
+use App\Services\Frontend\Migrations\Make\Values\EnsuredPluginMigrationHook;
+use App\Services\Frontend\Plugin\PluginFs;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 class MakeFrontendMigrationCommand extends Command implements PromptsForMissingInput
 {
     protected $signature = 'make:frontend-migration {name : The name of the frontend migration}';
-
     protected $description = 'Create a new migration file adding a new frontend migration';
 
     public function __construct(
-        readonly FrontendMigrationCreator $creator,
-        readonly Filesystem $files
-    )
-    {
+        public readonly FrontendMigrationCreator $creator,
+        public readonly PluginFs $pluginFs,
+    ) {
         parent::__construct();
     }
 
     public function handle(): void
     {
-        $plugins = $this->availablePlugins();
+        $plugins = $this->pluginFs->pluginNames();
 
         if (empty($plugins)) {
             $this->error('No plugins found in resources/js/plugins/.');
+
             return;
         }
 
         $plugin = $this->choice(
             'Which plugin should the JS migration belong to?',
-            $plugins
+            $plugins,
         );
 
-        $name = Str::snake(trim($this->input->getArgument('name')));
+        $name = Str::snake(mb_trim($this->input->getArgument('name')));
         $runType = $this->choice(
             'When should the JS migration run?',
             [
                 FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN => 'After user login',
                 FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY => 'After passkey verification',
-                'custom' => 'Custom (you will need to manually run the migration)'
+                'custom' => 'Custom (you will need to manually run the migration)',
             ],
-            FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN
+            FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN,
         );
 
-        if ($runType === 'custom') {
-            $runType = trim($this->ask('Enter the run type for the JS migration (e.g. after_login, after_passkey, or any custom identifier)'));
+        if ('custom' === $runType) {
+            $runType = mb_trim($this->ask('Enter the run type for the JS migration (e.g. after_login, after_passkey, or any custom identifier)'));
         }
 
         $result = $this->creator->create(
             name: $name,
             runType: $runType,
-            plugin: $plugin
+            plugin: $plugin,
         );
 
         $this->info('Frontend migration created successfully.');
-        $this->line('Backend migration: ' . $result['backendPath']);
-        $this->line('JS migration:      ' . $result['jsPath']);
+        $this->line('Backend migration: ' . $result->backendPath);
+        $this->line('JS migration:      ' . $result->jsPath);
 
-        $pluginPath = $result['pluginPath'];
-        $pluginStatus = $result['pluginStatus'];
-        if ($pluginStatus === PluginMigrationHookEnsurer::STATUS_ALREADY_CONFIGURED) {
-            $this->line('Plugin file:        ' . $pluginPath . ' (already configured)');
+        if (EnsuredPluginMigrationHook::STATUS_ALREADY_CONFIGURED === $result->pluginStatus) {
+            $this->line('Plugin file:        ' . $result->pluginPath . ' (already configured)');
         } else {
-            $this->line('Plugin file:        ' . $pluginPath . ' (updated: ' . $pluginStatus . ')');
+            $this->line('Plugin file:        ' . $result->pluginPath . ' (updated: ' . $result->pluginStatus . ')');
         }
     }
 
@@ -76,21 +75,5 @@ class MakeFrontendMigrationCommand extends Command implements PromptsForMissingI
         return [
             'name' => ['What should the migration be named?', 'E.g. update_user_to_new_format'],
         ];
-    }
-
-    private function availablePlugins(): array
-    {
-        $directories = $this->files->directories(resource_path('js/plugins'));
-        $plugins = [];
-
-        foreach ($directories as $directory) {
-            $pluginName = basename($directory);
-            $pluginFiles = $this->files->glob($directory . '/*.plugin.ts');
-            if (!empty($pluginFiles)) {
-                $plugins[] = $pluginName;
-            }
-        }
-
-        return $plugins;
     }
 }

--- a/app/Console/Commands/Make/MakeFrontendMigrationCommand.php
+++ b/app/Console/Commands/Make/MakeFrontendMigrationCommand.php
@@ -3,8 +3,10 @@
 namespace App\Console\Commands\Make;
 
 use App\Services\Frontend\Migrations\Make\FrontendMigrationCreator;
+use App\Services\Frontend\Migrations\Make\PluginMigrationHookEnsurer;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 class MakeFrontendMigrationCommand extends Command implements PromptsForMissingInput
@@ -14,7 +16,8 @@ class MakeFrontendMigrationCommand extends Command implements PromptsForMissingI
     protected $description = 'Create a new migration file adding a new frontend migration';
 
     public function __construct(
-        readonly FrontendMigrationCreator $creator
+        readonly FrontendMigrationCreator $creator,
+        readonly Filesystem $files
     )
     {
         parent::__construct();
@@ -22,6 +25,18 @@ class MakeFrontendMigrationCommand extends Command implements PromptsForMissingI
 
     public function handle(): void
     {
+        $plugins = $this->availablePlugins();
+
+        if (empty($plugins)) {
+            $this->error('No plugins found in resources/js/plugins/.');
+            return;
+        }
+
+        $plugin = $this->choice(
+            'Which plugin should the JS migration belong to?',
+            $plugins
+        );
+
         $name = Str::snake(trim($this->input->getArgument('name')));
         $runType = $this->choice(
             'When should the JS migration run?',
@@ -37,14 +52,23 @@ class MakeFrontendMigrationCommand extends Command implements PromptsForMissingI
             $runType = trim($this->ask('Enter the run type for the JS migration (e.g. after_login, after_passkey, or any custom identifier)'));
         }
 
-        [$backendMigrationPath, $jsMigrationPath] = $this->creator->create(
+        $result = $this->creator->create(
             name: $name,
-            runType: $runType
+            runType: $runType,
+            plugin: $plugin
         );
 
-        $this->info("Frontend migration created successfully.");
-        $this->line("Backend migration: " . $backendMigrationPath);
-        $this->line("JS migration: " . $jsMigrationPath);
+        $this->info('Frontend migration created successfully.');
+        $this->line('Backend migration: ' . $result['backendPath']);
+        $this->line('JS migration:      ' . $result['jsPath']);
+
+        $pluginPath = $result['pluginPath'];
+        $pluginStatus = $result['pluginStatus'];
+        if ($pluginStatus === PluginMigrationHookEnsurer::STATUS_ALREADY_CONFIGURED) {
+            $this->line('Plugin file:        ' . $pluginPath . ' (already configured)');
+        } else {
+            $this->line('Plugin file:        ' . $pluginPath . ' (updated: ' . $pluginStatus . ')');
+        }
     }
 
     protected function promptForMissingArgumentsUsing(): array
@@ -52,5 +76,21 @@ class MakeFrontendMigrationCommand extends Command implements PromptsForMissingI
         return [
             'name' => ['What should the migration be named?', 'E.g. update_user_to_new_format'],
         ];
+    }
+
+    private function availablePlugins(): array
+    {
+        $directories = $this->files->directories(resource_path('js/plugins'));
+        $plugins = [];
+
+        foreach ($directories as $directory) {
+            $pluginName = basename($directory);
+            $pluginFiles = $this->files->glob($directory . '/*.plugin.ts');
+            if (!empty($pluginFiles)) {
+                $plugins[] = $pluginName;
+            }
+        }
+
+        return $plugins;
     }
 }

--- a/app/Services/Frontend/Migrations/Make/FrontendMigrationCreator.php
+++ b/app/Services/Frontend/Migrations/Make/FrontendMigrationCreator.php
@@ -8,52 +8,44 @@ namespace App\Services\Frontend\Migrations\Make;
 use App\Services\System\Time\CarbonClockInterface;
 use Illuminate\Support\Str;
 
-/**
- * Scaffolds a new frontend migration by creating a paired set of stub files:
- * one Laravel PHP migration and one TypeScript migration for the frontend runner.
- *
- * Called by `MakeFrontendMigrationCommand` (`php artisan make:frontend-migration`).
- *
- * The generated filename follows the pattern:
- * `{timestamp}_{run_type}_{name}` — e.g. `2024_01_15_120000_after_login_update_user_prefs`.
- * The PHP stub lands in `database/migrations/` and the TS stub in
- * `resources/js/migrations/{run_type}/`.
- */
 readonly class FrontendMigrationCreator
 {
-    /** Run-type constant for migrations that execute immediately after the user logs in. */
     public const string RUN_TYPE_AFTER_LOGIN = 'after_login';
 
-    /** Run-type constant for migrations that execute after the user has unlocked their passkey. */
     public const string RUN_TYPE_AFTER_PASSKEY = 'after_passkey';
 
     public function __construct(
-        private BackendMigrationCreator $phpMigrationCreator,
-        private JsMigrationCreator      $jsMigrationCreator,
-        private CarbonClockInterface    $clock
+        private BackendMigrationCreator       $phpMigrationCreator,
+        private JsMigrationCreator            $jsMigrationCreator,
+        private CarbonClockInterface          $clock,
+        private PluginMigrationHookEnsurer    $pluginMigrationHookEnsurer
     )
     {
     }
 
     /**
-     * Creates both stub files and returns their absolute paths.
-     *
-     * @param string $name Snake-case migration name without timestamp or run-type prefix,
-     *                          e.g. `update_user_prefs`.
-     * @param string $runType When the JS migration should execute; use the `RUN_TYPE_*` constants
-     *                          or any custom string that matches a folder in `resources/js/migrations/`.
-     * @return array{0: string, 1: string} Tuple of [phpMigrationPath, jsMigrationPath].
+     * @param string $name   Snake-case migration name without timestamp or run-type prefix.
+     * @param string $runType When the JS migration executes.
+     * @param string $plugin  Plugin directory name under resources/js/plugins/.
+     * @return array{backendPath: string, jsPath: string, pluginPath: string, pluginStatus: string}
      */
-    public function create(string $name, string $runType): array
+    public function create(string $name, string $runType, string $plugin): array
     {
         $migrationName = $this->clock->now()->format('Y_m_d_His') . '_' . Str::snake($runType) . '_' . Str::snake($name);
 
         $phpMigrationPath = $this->phpMigrationCreator->create($migrationName, database_path('migrations'));
         $jsMigrationPath = $this->jsMigrationCreator->create(
             $migrationName,
-            resource_path('js/migrations/' . Str::snake($runType))
+            resource_path('js/plugins/' . $plugin . '/migrations/' . Str::snake($runType))
         );
 
-        return [$phpMigrationPath, $jsMigrationPath];
+        $pluginResult = $this->pluginMigrationHookEnsurer->ensure($plugin);
+
+        return [
+            'backendPath' => $phpMigrationPath,
+            'jsPath' => $jsMigrationPath,
+            'pluginPath' => $pluginResult['path'],
+            'pluginStatus' => $pluginResult['status'],
+        ];
     }
 }

--- a/app/Services/Frontend/Migrations/Make/FrontendMigrationCreator.php
+++ b/app/Services/Frontend/Migrations/Make/FrontendMigrationCreator.php
@@ -1,51 +1,52 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace App\Services\Frontend\Migrations\Make;
 
-
+use App\Services\Frontend\Migrations\Make\Values\CreatedFrontendMigration;
+use App\Services\Frontend\Plugin\PluginFs;
 use App\Services\System\Time\CarbonClockInterface;
 use Illuminate\Support\Str;
 
 readonly class FrontendMigrationCreator
 {
     public const string RUN_TYPE_AFTER_LOGIN = 'after_login';
-
     public const string RUN_TYPE_AFTER_PASSKEY = 'after_passkey';
 
     public function __construct(
-        private BackendMigrationCreator       $phpMigrationCreator,
-        private JsMigrationCreator            $jsMigrationCreator,
-        private CarbonClockInterface          $clock,
-        private PluginMigrationHookEnsurer    $pluginMigrationHookEnsurer
-    )
-    {
+        private BackendMigrationCreator $phpMigrationCreator,
+        private JsMigrationCreator $jsMigrationCreator,
+        private CarbonClockInterface $clock,
+        private PluginMigrationHookEnsurer $pluginMigrationHookEnsurer,
+        private PluginFs $pluginFs,
+    ) {
     }
 
     /**
-     * @param string $name   Snake-case migration name without timestamp or run-type prefix.
-     * @param string $runType When the JS migration executes.
-     * @param string $plugin  Plugin directory name under resources/js/plugins/.
-     * @return array{backendPath: string, jsPath: string, pluginPath: string, pluginStatus: string}
+     * Scaffolds the paired backend/JS migration files and ensures the plugin's `migrations()` hook.
+     *
+     * @param string $name    snake-case migration name without timestamp or run-type prefix
+     * @param string $runType when the JS migration executes
+     * @param string $plugin  plugin directory name under resources/js/plugins/
      */
-    public function create(string $name, string $runType, string $plugin): array
+    public function create(string $name, string $runType, string $plugin): CreatedFrontendMigration
     {
         $migrationName = $this->clock->now()->format('Y_m_d_His') . '_' . Str::snake($runType) . '_' . Str::snake($name);
 
         $phpMigrationPath = $this->phpMigrationCreator->create($migrationName, database_path('migrations'));
         $jsMigrationPath = $this->jsMigrationCreator->create(
             $migrationName,
-            resource_path('js/plugins/' . $plugin . '/migrations/' . Str::snake($runType))
+            $this->pluginFs->migrationsDirectoryForRunType($plugin, $runType),
         );
 
         $pluginResult = $this->pluginMigrationHookEnsurer->ensure($plugin);
 
-        return [
-            'backendPath' => $phpMigrationPath,
-            'jsPath' => $jsMigrationPath,
-            'pluginPath' => $pluginResult['path'],
-            'pluginStatus' => $pluginResult['status'],
-        ];
+        return new CreatedFrontendMigration(
+            backendPath: $phpMigrationPath,
+            jsPath: $jsMigrationPath,
+            pluginPath: $pluginResult->path,
+            pluginStatus: $pluginResult->status,
+        );
     }
 }

--- a/app/Services/Frontend/Migrations/Make/JsMigrationCreator.php
+++ b/app/Services/Frontend/Migrations/Make/JsMigrationCreator.php
@@ -11,9 +11,9 @@ use Symfony\Component\Filesystem\Path;
 /**
  * Writes the TypeScript migration stub for a new frontend migration.
  *
- * The stub is placed alongside the PHP migration in the run-type subfolder under
- * `resources/js/migrations/`. The frontend runner discovers it by filename and
- * executes the exported `migrate()` function in the user's browser.
+ * The stub is placed in the run-type subfolder of a plugin's `migrations/`
+ * directory. The frontend runner discovers it by filename and executes the
+ * exported `migrate()` function in the user's browser.
  */
 readonly class JsMigrationCreator
 {

--- a/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
+++ b/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
@@ -12,8 +12,9 @@ readonly class PluginMigrationHookEnsurer
 {
     public function __construct(
         private Filesystem $files,
-        private PluginFs $pluginFs,
-    ) {
+        private PluginFs   $pluginFs,
+    )
+    {
     }
 
     /**
@@ -31,28 +32,39 @@ readonly class PluginMigrationHookEnsurer
             return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_ALREADY_CONFIGURED);
         }
 
-        if (preg_match('/\bmigrations\s*\(/', $content) === 1) {
-            $this->files->put($pluginFile, $this->updateGlob($content, $expectedGlob));
+        // 1) Match method definitions in core plugin
+        // Similar regex to "updateGlob", but is more forgiving, so even if there is a "migrations" method,
+        // that does not contain an access modifier, it will still trigger the exception.
+        if (preg_match('/^\s+(public\s+)?migrations\s*\(/', $content) === 1) {
+            $updated = $this->updateGlob($content, $expectedGlob);
 
+            // 2) Throw for unexpected migration globs
+            if ($updated === null) {
+                throw new \RuntimeException(
+                    "Found a migrations() hook in {$pluginFile} but could not safely update its glob. Please wire it manually to: {$expectedGlob}"
+                );
+            }
+
+            $this->files->put($pluginFile, $updated);
             return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_UPDATED_GLOB);
         }
 
         $this->files->put($pluginFile, $this->addMigrationHook($content, $expectedGlob));
-
         return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_ADDED_HOOK);
     }
 
-        $offset = 0;
-
-        if (preg_match('/\bmigrations\s*\(/', $content, $migrationMatch, \PREG_OFFSET_CAPTURE) === 1) {
-            $offset = $migrationMatch[0][1];
+    private function updateGlob(string $content, string $glob): ?string
+    {
+        // Definition-anchored match; null-return means "not found", never fall back to offset 0
+        if (preg_match('/public\s+migrations\s*\(/', $content, $migrationMatch, \PREG_OFFSET_CAPTURE) !== 1) {
+            return null;
         }
 
-        if (preg_match('/import\.meta\.glob\(\s*[\'\"][^\'\"]*[\'\"]/', $content, $matches, \PREG_OFFSET_CAPTURE, $offset) === 1) {
-            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], \strlen($matches[0][0]));
+        if (preg_match('/import\.meta\.glob\(\s*[\'"][^\'"]*[\'"]/', $content, $matches, \PREG_OFFSET_CAPTURE, $migrationMatch[0][1]) !== 1) {
+            return null; // hook exists but contains no glob — refuse to guess
         }
 
-        return $content;
+        return substr_replace($content, "import.meta.glob('" . $glob . "')", $matches[0][1], \strlen($matches[0][0]));
     }
 
     private function addMigrationHook(string $content, string $glob): string

--- a/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
+++ b/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+
+namespace App\Services\Frontend\Migrations\Make;
+
+
+use Illuminate\Filesystem\Filesystem;
+use RuntimeException;
+
+readonly class PluginMigrationHookEnsurer
+{
+    public const string STATUS_ALREADY_CONFIGURED = 'already configured';
+    public const string STATUS_ADDED_HOOK = 'added migrations hook';
+    public const string STATUS_UPDATED_GLOB = 'updated migrations glob';
+
+    public function __construct(private Filesystem $files)
+    {
+    }
+
+    /**
+     * @param string $plugin Plugin name (directory name under resources/js/plugins/).
+     * @return array{path: string, status: string}
+     */
+    public function ensure(string $plugin): array
+    {
+        $pluginFiles = $this->files->glob(resource_path('js/plugins/' . $plugin . '/*.plugin.ts'));
+        if (empty($pluginFiles)) {
+            throw new RuntimeException("No .plugin.ts file found for plugin '$plugin'.");
+        }
+        $pluginFile = $pluginFiles[0];
+
+        $content = $this->files->get($pluginFile);
+        $expectedGlob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
+
+        if (str_contains($content, $expectedGlob)) {
+            return ['path' => $pluginFile, 'status' => self::STATUS_ALREADY_CONFIGURED];
+        }
+
+        if (preg_match('/\bmigrations\s*\(/', $content) === 1) {
+            $content = $this->updateGlob($content, $plugin);
+            $this->files->put($pluginFile, $content);
+
+            return ['path' => $pluginFile, 'status' => self::STATUS_UPDATED_GLOB];
+        }
+
+        $content = $this->addMigrationHook($content, $plugin);
+        $this->files->put($pluginFile, $content);
+
+        return ['path' => $pluginFile, 'status' => self::STATUS_ADDED_HOOK];
+    }
+
+    private function updateGlob(string $content, string $plugin): string
+    {
+        $glob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
+        $offset = strpos($content, 'migrations(');
+
+        if (preg_match('/import\.meta\.glob\(\s*[\'"][^\'"]*[\'"]/', $content, $matches, PREG_OFFSET_CAPTURE, $offset) === 1) {
+            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], strlen($matches[0][0]));
+        }
+
+        return $content;
+    }
+
+    private function addMigrationHook(string $content, string $plugin): string
+    {
+        $content = $this->ensureImport($content, "import type {MigrationRegistrar} from '\$lib/kernel/migrations/migrationRegistrar.js';");
+        $content = $this->ensureCorePluginType($content);
+
+        $glob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
+        $method = "    public migrations(registrar: MigrationRegistrar): void | Promise<void> {\n"
+            . "        registrar.addFromModules(import.meta.glob('" . $glob . "', {eager: false}));\n"
+            . "    }\n";
+
+        $lastBrace = strrpos($content, '}');
+        if ($lastBrace === false) {
+            return $content . "\n" . $method;
+        }
+
+        return substr($content, 0, $lastBrace) . $method . substr($content, $lastBrace);
+    }
+
+    private function ensureImport(string $content, string $import): string
+    {
+        if (str_contains($content, $import)) {
+            return $content;
+        }
+
+        $lines = explode("\n", $content);
+        $lastImportIndex = -1;
+        foreach ($lines as $index => $line) {
+            if (preg_match('/^import\b/', ltrim($line)) === 1) {
+                $lastImportIndex = $index;
+            }
+        }
+
+        if ($lastImportIndex >= 0) {
+            array_splice($lines, $lastImportIndex + 1, 0, [$import]);
+        } else {
+            array_unshift($lines, $import);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function ensureCorePluginType(string $content): string
+    {
+        if (!str_contains($content, 'HawkiCorePlugin')) {
+            if (str_contains($content, 'HawkiPlugin')) {
+                $content = preg_replace('/\{HawkiPlugin\}/', '{HawkiCorePlugin}', $content, 1);
+            } else {
+                $content = $this->ensureImport($content, "import type {HawkiCorePlugin} from '\$lib/kernel/plugins/types.js';");
+            }
+        }
+
+        if (str_contains($content, 'implements HawkiPlugin')) {
+            $content = str_replace('implements HawkiPlugin', 'implements HawkiCorePlugin', $content);
+        }
+
+        return $content;
+    }
+}

--- a/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
+++ b/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
@@ -1,83 +1,74 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace App\Services\Frontend\Migrations\Make;
 
-
+use App\Services\Frontend\Migrations\Make\Values\EnsuredPluginMigrationHook;
+use App\Services\Frontend\Plugin\PluginFs;
 use Illuminate\Filesystem\Filesystem;
-use RuntimeException;
 
 readonly class PluginMigrationHookEnsurer
 {
-    public const string STATUS_ALREADY_CONFIGURED = 'already configured';
-    public const string STATUS_ADDED_HOOK = 'added migrations hook';
-    public const string STATUS_UPDATED_GLOB = 'updated migrations glob';
-
-    public function __construct(private Filesystem $files)
-    {
+    public function __construct(
+        private Filesystem $files,
+        private PluginFs $pluginFs,
+    ) {
     }
 
     /**
-     * @param string $plugin Plugin name (directory name under resources/js/plugins/).
-     * @return array{path: string, status: string}
+     * Ensures the plugin's `.plugin.ts` file has a `migrations()` hook that globs the correct
+     * migrations directory. Adds or updates the hook, the `MigrationRegistrar` import, and the
+     * `HawkiCorePlugin` type as needed.
      */
-    public function ensure(string $plugin): array
+    public function ensure(string $plugin): EnsuredPluginMigrationHook
     {
-        $pluginFiles = $this->files->glob(resource_path('js/plugins/' . $plugin . '/*.plugin.ts'));
-        if (empty($pluginFiles)) {
-            throw new RuntimeException("No .plugin.ts file found for plugin '$plugin'.");
-        }
-        $pluginFile = $pluginFiles[0];
-
+        $pluginFile = $this->pluginFs->pluginFilePath($plugin);
         $content = $this->files->get($pluginFile);
-        $expectedGlob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
+        $expectedGlob = $this->pluginFs->migrationsTsGlob($plugin);
 
         if (str_contains($content, $expectedGlob)) {
-            return ['path' => $pluginFile, 'status' => self::STATUS_ALREADY_CONFIGURED];
+            return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_ALREADY_CONFIGURED);
         }
 
         if (preg_match('/\bmigrations\s*\(/', $content) === 1) {
-            $content = $this->updateGlob($content, $plugin);
-            $this->files->put($pluginFile, $content);
+            $this->files->put($pluginFile, $this->updateGlob($content, $expectedGlob));
 
-            return ['path' => $pluginFile, 'status' => self::STATUS_UPDATED_GLOB];
+            return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_UPDATED_GLOB);
         }
 
-        $content = $this->addMigrationHook($content, $plugin);
-        $this->files->put($pluginFile, $content);
+        $this->files->put($pluginFile, $this->addMigrationHook($content, $expectedGlob));
 
-        return ['path' => $pluginFile, 'status' => self::STATUS_ADDED_HOOK];
+        return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_ADDED_HOOK);
     }
 
-    private function updateGlob(string $content, string $plugin): string
+    private function updateGlob(string $content, string $glob): string
     {
-        $glob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
-        $offset = strpos($content, 'migrations(');
+        $offset = mb_strpos($content, 'migrations(');
 
-        if (preg_match('/import\.meta\.glob\(\s*[\'"][^\'"]*[\'"]/', $content, $matches, PREG_OFFSET_CAPTURE, $offset) === 1) {
-            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], strlen($matches[0][0]));
+        if (preg_match('/import\.meta\.glob\(\s*[\'"][^\'"]*[\'"]/', $content, $matches, \PREG_OFFSET_CAPTURE, $offset) === 1) {
+            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], mb_strlen($matches[0][0]));
         }
 
         return $content;
     }
 
-    private function addMigrationHook(string $content, string $plugin): string
+    private function addMigrationHook(string $content, string $glob): string
     {
         $content = $this->ensureImport($content, "import type {MigrationRegistrar} from '\$lib/kernel/migrations/migrationRegistrar.js';");
         $content = $this->ensureCorePluginType($content);
 
-        $glob = '$lib/plugins/' . $plugin . '/migrations/**/*.ts';
         $method = "    public migrations(registrar: MigrationRegistrar): void | Promise<void> {\n"
             . "        registrar.addFromModules(import.meta.glob('" . $glob . "', {eager: false}));\n"
             . "    }\n";
 
-        $lastBrace = strrpos($content, '}');
-        if ($lastBrace === false) {
+        $lastBrace = mb_strrpos($content, '}');
+
+        if (false === $lastBrace) {
             return $content . "\n" . $method;
         }
 
-        return substr($content, 0, $lastBrace) . $method . substr($content, $lastBrace);
+        return mb_substr($content, 0, $lastBrace) . $method . mb_substr($content, $lastBrace);
     }
 
     private function ensureImport(string $content, string $import): string
@@ -88,13 +79,14 @@ readonly class PluginMigrationHookEnsurer
 
         $lines = explode("\n", $content);
         $lastImportIndex = -1;
+
         foreach ($lines as $index => $line) {
-            if (preg_match('/^import\b/', ltrim($line)) === 1) {
+            if (preg_match('/^import\b/', mb_ltrim($line)) === 1) {
                 $lastImportIndex = $index;
             }
         }
 
-        if ($lastImportIndex >= 0) {
+        if (0 <= $lastImportIndex) {
             array_splice($lines, $lastImportIndex + 1, 0, [$import]);
         } else {
             array_unshift($lines, $import);

--- a/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
+++ b/app/Services/Frontend/Migrations/Make/PluginMigrationHookEnsurer.php
@@ -42,12 +42,14 @@ readonly class PluginMigrationHookEnsurer
         return new EnsuredPluginMigrationHook($pluginFile, EnsuredPluginMigrationHook::STATUS_ADDED_HOOK);
     }
 
-    private function updateGlob(string $content, string $glob): string
-    {
-        $offset = mb_strpos($content, 'migrations(');
+        $offset = 0;
 
-        if (preg_match('/import\.meta\.glob\(\s*[\'"][^\'"]*[\'"]/', $content, $matches, \PREG_OFFSET_CAPTURE, $offset) === 1) {
-            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], mb_strlen($matches[0][0]));
+        if (preg_match('/\bmigrations\s*\(/', $content, $migrationMatch, \PREG_OFFSET_CAPTURE) === 1) {
+            $offset = $migrationMatch[0][1];
+        }
+
+        if (preg_match('/import\.meta\.glob\(\s*[\'\"][^\'\"]*[\'\"]/', $content, $matches, \PREG_OFFSET_CAPTURE, $offset) === 1) {
+            return substr_replace($content, "import.meta.glob('" . $glob . "'", $matches[0][1], \strlen($matches[0][0]));
         }
 
         return $content;

--- a/app/Services/Frontend/Migrations/Make/Values/CreatedFrontendMigration.php
+++ b/app/Services/Frontend/Migrations/Make/Values/CreatedFrontendMigration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Frontend\Migrations\Make\Values;
+
+/**
+ * Result of {@see \App\Services\Frontend\Migrations\Make\FrontendMigrationCreator::create()} —
+ * the absolute paths of the scaffolded backend and JS migration files plus the outcome of
+ * ensuring the plugin's `migrations()` hook.
+ */
+readonly class CreatedFrontendMigration
+{
+    public function __construct(
+        /**
+         * Absolute path to the generated Laravel database migration file.
+         */
+        public string $backendPath,
+        /**
+         * Absolute path to the generated TypeScript migration file.
+         */
+        public string $jsPath,
+        /**
+         * Absolute path to the plugin's `.plugin.ts` file that was inspected/updated.
+         */
+        public string $pluginPath,
+        /**
+         * Outcome of the plugin hook check — one of the {@see EnsuredPluginMigrationHook} status constants.
+         */
+        public string $pluginStatus,
+    ) {
+    }
+}

--- a/app/Services/Frontend/Migrations/Make/Values/EnsuredPluginMigrationHook.php
+++ b/app/Services/Frontend/Migrations/Make/Values/EnsuredPluginMigrationHook.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Frontend\Migrations\Make\Values;
+
+/**
+ * Result of {@see \App\Services\Frontend\Migrations\Make\PluginMigrationHookEnsurer::ensure()} —
+ * the plugin file that was inspected and whether its `migrations()` hook was already present,
+ * updated, or added.
+ */
+readonly class EnsuredPluginMigrationHook
+{
+    /**
+     * The plugin file already contained a `migrations()` hook globbing the correct path.
+     */
+    public const string STATUS_ALREADY_CONFIGURED = 'already configured';
+
+    /**
+     * A `migrations()` hook existed but globbed the wrong path; the glob was updated.
+     */
+    public const string STATUS_UPDATED_GLOB = 'updated migrations glob';
+
+    /**
+     * No `migrations()` hook was present; the hook, imports, and `HawkiCorePlugin` were added.
+     */
+    public const string STATUS_ADDED_HOOK = 'added migrations hook';
+
+    public function __construct(
+        /**
+         * Absolute path to the plugin's `.plugin.ts` file.
+         */
+        public string $path,
+        /**
+         * Outcome of the check — one of the `STATUS_*` constants.
+         */
+        public string $status,
+    ) {
+    }
+}

--- a/app/Services/Frontend/Migrations/Make/stubs/js_migration.stub
+++ b/app/Services/Frontend/Migrations/Make/stubs/js_migration.stub
@@ -1,4 +1,4 @@
-import type {MigrationContext} from '$lib/data/migrations/migrator.js';
+import type {MigrationContext} from '$lib/kernel/migrations/MigrationExtension.js';
 
 export async function migrate({name}: MigrationContext) {
     console.log(`Running dummy migration ${name}...`);

--- a/app/Services/Frontend/Plugin/PluginFs.php
+++ b/app/Services/Frontend/Plugin/PluginFs.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Frontend\Plugin;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+/**
+ * Single source of truth for the on-disk layout of frontend plugins and the matching
+ * TypeScript path/glob strings emitted into generated code.
+ *
+ * Frontend plugins live under `resources/js/plugins/`, which the Vite `$lib` alias resolves
+ * to `$lib/plugins/`. Each plugin is a subdirectory containing a `*.plugin.ts` file, discovered
+ * by `PluginExtension` via a recursive glob (see {@see pluginFileTsGlob()}).
+ *
+ * Centralising these strings here keeps the backend (artisan commands, migration scaffolders)
+ * and the TypeScript it generates in sync with the frontend's plugin discovery contract.
+ */
+readonly class PluginFs
+{
+    /**
+     * TypeScript prefix for the plugins root, matching the Vite `$lib` alias.
+     */
+    public const string TS_PLUGINS_PREFIX = '$lib/plugins';
+
+    /**
+     * Glob pattern used by `PluginExtension` to discover `*.plugin.ts` files.
+     */
+    public const string PLUGIN_FILE_TS_GLOB = self::TS_PLUGINS_PREFIX . '/**/*.plugin.ts';
+
+    public function __construct(private Filesystem $files)
+    {
+    }
+
+    /**
+     * Absolute filesystem path to the plugins root directory.
+     */
+    public function pluginsRoot(): string
+    {
+        return resource_path('js/plugins');
+    }
+
+    /**
+     * TypeScript glob matching every `*.plugin.ts` file across all plugins (the discovery glob).
+     */
+    public function pluginFileTsGlob(): string
+    {
+        return self::PLUGIN_FILE_TS_GLOB;
+    }
+
+    /**
+     * Lists every plugin name — a directory under the plugins root that contains a `*.plugin.ts`.
+     *
+     * @return array<int, string>
+     */
+    public function pluginNames(): array
+    {
+        $names = [];
+
+        foreach ($this->files->directories($this->pluginsRoot()) as $directory) {
+            $name = basename($directory);
+
+            if ($this->hasPluginFile($directory)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Resolves the absolute filesystem path of a plugin's `*.plugin.ts` file.
+     *
+     * @throws \RuntimeException When the plugin has no (or multiple) `*.plugin.ts` file.
+     */
+    public function pluginFilePath(string $plugin): string
+    {
+        $matches = $this->files->glob($this->pluginDirectory($plugin) . '/*.plugin.ts');
+
+        if (\count($matches) === 0) {
+            throw new \RuntimeException("No .plugin.ts file found for plugin '{$plugin}'.");
+        }
+
+        if (\count($matches) > 1) {
+            throw new \RuntimeException("Plugin '{$plugin}' has multiple .plugin.ts files.");
+        }
+
+        return $matches[0];
+    }
+
+    /**
+     * Absolute filesystem path to a plugin's migrations directory.
+     */
+    public function migrationsDirectory(string $plugin): string
+    {
+        return $this->pluginDirectory($plugin) . '/migrations';
+    }
+
+    /**
+     * Absolute filesystem path to a plugin's migrations directory for the given run type.
+     * The run type is snake-cased to match the directory convention used by the frontend runner.
+     */
+    public function migrationsDirectoryForRunType(string $plugin, string $runType): string
+    {
+        return $this->migrationsDirectory($plugin) . '/' . Str::snake($runType);
+    }
+
+    /**
+     * TypeScript `import.meta.glob` pattern matching every `*.ts` file under a plugin's
+     * migrations directory — used by the plugin's `migrations()` lifecycle hook.
+     */
+    public function migrationsTsGlob(string $plugin): string
+    {
+        return self::TS_PLUGINS_PREFIX . '/' . $plugin . '/migrations/**/*.ts';
+    }
+
+    /**
+     * Absolute filesystem path to a plugin's root directory.
+     */
+    private function pluginDirectory(string $plugin): string
+    {
+        return $this->pluginsRoot() . '/' . $plugin;
+    }
+
+    /**
+     * Returns true when `$directory` contains at least one `*.plugin.ts` file.
+     */
+    private function hasPluginFile(string $directory): bool
+    {
+        return !empty($this->files->glob($directory . '/*.plugin.ts'));
+    }
+}

--- a/tests/Unit/Services/Frontend/Migrations/Make/FrontendMigrationCreatorTest.php
+++ b/tests/Unit/Services/Frontend/Migrations/Make/FrontendMigrationCreatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Services\Frontend\Migrations\Make;
@@ -7,6 +8,8 @@ use App\Services\Frontend\Migrations\Make\BackendMigrationCreator;
 use App\Services\Frontend\Migrations\Make\FrontendMigrationCreator;
 use App\Services\Frontend\Migrations\Make\JsMigrationCreator;
 use App\Services\Frontend\Migrations\Make\PluginMigrationHookEnsurer;
+use App\Services\Frontend\Migrations\Make\Values\CreatedFrontendMigration;
+use App\Services\Frontend\Plugin\PluginFs;
 use App\Services\System\Time\CarbonClock;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -21,12 +24,12 @@ class FrontendMigrationCreatorTest extends TestCase
 
     public function testItDefinesRunTypeAfterLogin(): void
     {
-        static::assertSame('after_login', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
+        self::assertSame('after_login', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
     }
 
     public function testItDefinesRunTypeAfterPasskey(): void
     {
-        static::assertSame('after_passkey', FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY);
+        self::assertSame('after_passkey', FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY);
     }
 
     // =========================================================================
@@ -36,73 +39,70 @@ class FrontendMigrationCreatorTest extends TestCase
     public function testItConstructs(): void
     {
         $sut = $this->makeSut();
-        static::assertInstanceOf(FrontendMigrationCreator::class, $sut);
+        self::assertInstanceOf(FrontendMigrationCreator::class, $sut);
     }
 
-    public function testItReturnsPathsAndPluginStatus(): void
+    public function testItReturnsCreatedFrontendMigrationDto(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertArrayHasKey('backendPath', $result);
-        static::assertArrayHasKey('jsPath', $result);
-        static::assertArrayHasKey('pluginPath', $result);
-        static::assertArrayHasKey('pluginStatus', $result);
+        self::assertInstanceOf(CreatedFrontendMigration::class, $result);
     }
 
     public function testItReturnsPhpPathAsBackendPath(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringEndsWith('.php', $result['backendPath']);
+        self::assertStringEndsWith('.php', $result->backendPath);
     }
 
     public function testItReturnsTsPathAsJsPath(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringEndsWith('.ts', $result['jsPath']);
+        self::assertStringEndsWith('.ts', $result->jsPath);
     }
 
     public function testItIncludesTimestampInMigrationName(): void
     {
         $sut = $this->makeSut(new \DateTimeImmutable('2024-01-15 12:00:00'));
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringContainsString('2024_01_15_120000', $result['backendPath']);
+        self::assertStringContainsString('2024_01_15_120000', $result->backendPath);
     }
 
     public function testItIncludesRunTypeInMigrationName(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringContainsString('after_login', $result['backendPath']);
+        self::assertStringContainsString('after_login', $result->backendPath);
     }
 
     public function testItIncludesNameInMigrationName(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('my_widget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringContainsString('my_widget', $result['backendPath']);
+        self::assertStringContainsString('my_widget', $result->backendPath);
     }
 
     public function testItConvertsNameToSnakeCase(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('myWidget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
-        static::assertStringContainsString('my_widget', $result['backendPath']);
+        self::assertStringContainsString('my_widget', $result->backendPath);
     }
 
     public function testItConvertsCamelCaseRunTypeToSnakeCase(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', 'afterLogin', 'test_plugin');
-        static::assertStringContainsString('after_login', $result['backendPath']);
+        self::assertStringContainsString('after_login', $result->backendPath);
     }
 
     public function testJsMigrationGoesIntoPluginRunTypeSubfolder(): void
     {
         $sut = $this->makeSut();
         $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY, 'test_plugin');
-        static::assertStringContainsString('plugins/test_plugin/migrations/after_passkey', $result['jsPath']);
+        self::assertStringContainsString('plugins/test_plugin/migrations/after_passkey', $result->jsPath);
     }
 
     public function testBothFilesShareTheSameMigrationName(): void
@@ -110,9 +110,9 @@ class FrontendMigrationCreatorTest extends TestCase
         $sut = $this->makeSut(new \DateTimeImmutable('2024-06-01 09:30:00'));
         $result = $sut->create('update_user', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
 
-        $phpBasename = pathinfo($result['backendPath'], PATHINFO_FILENAME);
-        $tsBasename = pathinfo($result['jsPath'], PATHINFO_FILENAME);
-        static::assertSame($phpBasename, $tsBasename);
+        $phpBasename = pathinfo($result->backendPath, \PATHINFO_FILENAME);
+        $tsBasename = pathinfo($result->jsPath, \PATHINFO_FILENAME);
+        self::assertSame($phpBasename, $tsBasename);
     }
 
     // =========================================================================
@@ -130,11 +130,14 @@ class FrontendMigrationCreatorTest extends TestCase
 
         $clock = new CarbonClock($now ?? new \DateTimeImmutable('2024-01-01 00:00:00'));
 
+        $pluginFs = new PluginFs($pluginFiles);
+
         return new FrontendMigrationCreator(
             phpMigrationCreator: new BackendMigrationCreator($files),
             jsMigrationCreator: new JsMigrationCreator($files),
             clock: $clock,
-            pluginMigrationHookEnsurer: new PluginMigrationHookEnsurer($pluginFiles)
+            pluginMigrationHookEnsurer: new PluginMigrationHookEnsurer($pluginFiles, $pluginFs),
+            pluginFs: $pluginFs,
         );
     }
 }

--- a/tests/Unit/Services/Frontend/Migrations/Make/FrontendMigrationCreatorTest.php
+++ b/tests/Unit/Services/Frontend/Migrations/Make/FrontendMigrationCreatorTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Services\Frontend\Migrations\Make;
 use App\Services\Frontend\Migrations\Make\BackendMigrationCreator;
 use App\Services\Frontend\Migrations\Make\FrontendMigrationCreator;
 use App\Services\Frontend\Migrations\Make\JsMigrationCreator;
+use App\Services\Frontend\Migrations\Make\PluginMigrationHookEnsurer;
 use App\Services\System\Time\CarbonClock;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -38,76 +39,79 @@ class FrontendMigrationCreatorTest extends TestCase
         static::assertInstanceOf(FrontendMigrationCreator::class, $sut);
     }
 
-    public function testItReturnsTwoFilePaths(): void
+    public function testItReturnsPathsAndPluginStatus(): void
     {
         $sut = $this->makeSut();
-        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertCount(2, $result);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertArrayHasKey('backendPath', $result);
+        static::assertArrayHasKey('jsPath', $result);
+        static::assertArrayHasKey('pluginPath', $result);
+        static::assertArrayHasKey('pluginStatus', $result);
     }
 
-    public function testItReturnsPhpPathAsFirstElement(): void
+    public function testItReturnsPhpPathAsBackendPath(): void
     {
         $sut = $this->makeSut();
-        [$phpPath] = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringEndsWith('.php', $phpPath);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringEndsWith('.php', $result['backendPath']);
     }
 
-    public function testItReturnsTsPathAsSecondElement(): void
+    public function testItReturnsTsPathAsJsPath(): void
     {
         $sut = $this->makeSut();
-        [, $tsPath] = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringEndsWith('.ts', $tsPath);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringEndsWith('.ts', $result['jsPath']);
     }
 
     public function testItIncludesTimestampInMigrationName(): void
     {
         $sut = $this->makeSut(new \DateTimeImmutable('2024-01-15 12:00:00'));
-        [$phpPath] = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringContainsString('2024_01_15_120000', $phpPath);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringContainsString('2024_01_15_120000', $result['backendPath']);
     }
 
     public function testItIncludesRunTypeInMigrationName(): void
     {
         $sut = $this->makeSut();
-        [$phpPath] = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringContainsString('after_login', $phpPath);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringContainsString('after_login', $result['backendPath']);
     }
 
     public function testItIncludesNameInMigrationName(): void
     {
         $sut = $this->makeSut();
-        [$phpPath] = $sut->create('my_widget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringContainsString('my_widget', $phpPath);
+        $result = $sut->create('my_widget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringContainsString('my_widget', $result['backendPath']);
     }
 
     public function testItConvertsNameToSnakeCase(): void
     {
         $sut = $this->makeSut();
-        [$phpPath] = $sut->create('myWidget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
-        static::assertStringContainsString('my_widget', $phpPath);
+        $result = $sut->create('myWidget', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
+        static::assertStringContainsString('my_widget', $result['backendPath']);
     }
 
     public function testItConvertsCamelCaseRunTypeToSnakeCase(): void
     {
         $sut = $this->makeSut();
-        [$phpPath] = $sut->create('test_migration', 'afterLogin');
-        static::assertStringContainsString('after_login', $phpPath);
+        $result = $sut->create('test_migration', 'afterLogin', 'test_plugin');
+        static::assertStringContainsString('after_login', $result['backendPath']);
     }
 
-    public function testJsMigrationGoesIntoRunTypeSubfolder(): void
+    public function testJsMigrationGoesIntoPluginRunTypeSubfolder(): void
     {
         $sut = $this->makeSut();
-        [, $tsPath] = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY);
-        static::assertStringContainsString('after_passkey', $tsPath);
+        $result = $sut->create('test_migration', FrontendMigrationCreator::RUN_TYPE_AFTER_PASSKEY, 'test_plugin');
+        static::assertStringContainsString('plugins/test_plugin/migrations/after_passkey', $result['jsPath']);
     }
 
     public function testBothFilesShareTheSameMigrationName(): void
     {
         $sut = $this->makeSut(new \DateTimeImmutable('2024-06-01 09:30:00'));
-        [$phpPath, $tsPath] = $sut->create('update_user', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN);
+        $result = $sut->create('update_user', FrontendMigrationCreator::RUN_TYPE_AFTER_LOGIN, 'test_plugin');
 
-        $phpBasename = pathinfo($phpPath, PATHINFO_FILENAME);
-        $tsBasename = pathinfo($tsPath, PATHINFO_FILENAME);
+        $phpBasename = pathinfo($result['backendPath'], PATHINFO_FILENAME);
+        $tsBasename = pathinfo($result['jsPath'], PATHINFO_FILENAME);
         static::assertSame($phpBasename, $tsBasename);
     }
 
@@ -120,12 +124,17 @@ class FrontendMigrationCreatorTest extends TestCase
         $files = $this->createMock(Filesystem::class);
         $files->method('get')->willReturn('');
 
+        $pluginFiles = $this->createMock(Filesystem::class);
+        $pluginFiles->method('glob')->willReturn(['/tmp/js/plugins/test_plugin/test_plugin.plugin.ts']);
+        $pluginFiles->method('get')->willReturn('');
+
         $clock = new CarbonClock($now ?? new \DateTimeImmutable('2024-01-01 00:00:00'));
 
         return new FrontendMigrationCreator(
             phpMigrationCreator: new BackendMigrationCreator($files),
             jsMigrationCreator: new JsMigrationCreator($files),
-            clock: $clock
+            clock: $clock,
+            pluginMigrationHookEnsurer: new PluginMigrationHookEnsurer($pluginFiles)
         );
     }
 }


### PR DESCRIPTION
This pull request implements plugin-aware frontend migrations, allowing JavaScript migration files to be generated within specific plugin directories and ensuring that each plugin is correctly configured to register its own migrations. The changes include significant updates to the migration command, core migration creator logic, and plugin configuration, as well as corresponding updates to tests and stubs.

**Plugin-aware frontend migrations and plugin configuration:**

* The `MakeFrontendMigrationCommand` now prompts the user to select a plugin, generates the JS migration inside the chosen plugin's directory, and displays the status of the plugin's migration hook configuration. It uses a new `PluginMigrationHookEnsurer` service to ensure the plugin is set up to register migrations. [[1]](diffhunk://#diff-f12400c918cb26ca4fd04e6653a2ffbd9e39c8b6cd56dd534b95d73f0edf2a36R6-R9) [[2]](diffhunk://#diff-f12400c918cb26ca4fd04e6653a2ffbd9e39c8b6cd56dd534b95d73f0edf2a36L17-R39) [[3]](diffhunk://#diff-f12400c918cb26ca4fd04e6653a2ffbd9e39c8b6cd56dd534b95d73f0edf2a36L40-R71) [[4]](diffhunk://#diff-f12400c918cb26ca4fd04e6653a2ffbd9e39c8b6cd56dd534b95d73f0edf2a36R80-R95)
* The `FrontendMigrationCreator` and `JsMigrationCreator` classes were refactored to support plugin directories for JS migrations and to return detailed information about migration file paths and plugin configuration status. [[1]](diffhunk://#diff-49da0fce354916c84bd9035b39a47786f5f39cddbb262c11aebec4767c5c05b2L11-R49) [[2]](diffhunk://#diff-92b6d82fc453048f8d90bcb9b1ace8105d7a1534b5590198f2eef37eccc8b77dL14-R16)
* A new `PluginMigrationHookEnsurer` service was added, which checks and updates the plugin's `.plugin.ts` file to ensure it registers migrations. It handles adding or updating the migration hook as needed.

**Testing and stubs updates:**

* Unit tests for `FrontendMigrationCreator` were updated to reflect the new plugin-aware migration creation process and to verify that the correct paths and statuses are returned. [[1]](diffhunk://#diff-d0ef10823d969faff4152c9aeb82f4eb99c27c393c479d9b01ffce30c0cfda51R9) [[2]](diffhunk://#diff-d0ef10823d969faff4152c9aeb82f4eb99c27c393c479d9b01ffce30c0cfda51L41-R114) [[3]](diffhunk://#diff-d0ef10823d969faff4152c9aeb82f4eb99c27c393c479d9b01ffce30c0cfda51R127-R137)
* The migration stub was updated to import from the new migration context location.…and ensure migration hooks