### PR TITLE
dev-bug: Fix console warnings concerning stream handling and layout c…

### DIFF
--- a/public/js/ai_chat_functions.js
+++ b/public/js/ai_chat_functions.js
@@ -161,7 +161,6 @@ async function sendMessageConv(payload) {
             }
         };
         await buildRequestObjectForAiConv(response, msgAttributes);
-        response.triggerReceived();
     });
 }
 
@@ -205,7 +204,9 @@ async function buildRequestObjectForAiConv(
                     window.oldUiBridge.triggerSendToast(
                         data.content, 'error'
                     );
-                    response.triggerReceived();
+                    if (!response.done) {
+                        response.triggerReceived();
+                    }
                     resolve();
                     return;
                 } else if (data.type === 'header') {
@@ -276,6 +277,10 @@ async function buildRequestObjectForAiConv(
                 }
 
                 if (!headerReceived || !messageElement || !messageObj) {
+                    if (!response.done) {
+                        response.triggerReceived();
+                    }
+                    resolve();
                     return;
                 }
 
@@ -331,12 +336,16 @@ async function buildRequestObjectForAiConv(
                     isDone(true);
                 }
 
-                response.triggerReceived();
+                if (!response.done) {
+                    response.triggerReceived();
+                }
 
                 resolve();
             }
         }, () => {
-            response.triggerError(window.__('legacy.aiChat.streamProcessingError'));
+            if (!response.done) {
+                response.triggerError(window.__('legacy.aiChat.streamProcessingError'));
+            }
             if (!isUpdate && messageElement) {
                 messageElement.remove();
             }

--- a/resources/js/utils/transitions/growTransition.ts
+++ b/resources/js/utils/transitions/growTransition.ts
@@ -8,8 +8,6 @@
  * horizontally when a file upload begins.
  *
  * @param node - The element being transitioned (provided by Svelte).
- * @param params.direction - `'in'` (enter, default) or `'out'` (leave).
- *   Enter uses a gentle spring overshoot; leave uses `cubicOut`.
  * @param params.mode - `'vertical'` (default, animates height) or
  *   `'horizontal'` (animates width).
  *
@@ -17,52 +15,68 @@
  * // Vertical grow (default)
  * <div transition:growTransition>…</div>
  *
- * // Horizontal grow, enter only
+ * // Horizontal grow
  * <span in:growTransition={{mode: 'horizontal'}}>…</span>
  */
-import {cubicOut} from 'svelte/easing';
-
 function gentleBackOut(t: number) {
     const s = 0.6;
     return 1 + (s + 1) * Math.pow(t - 1, 3) + s * Math.pow(t - 1, 2);
 }
 
-export function growTransition(node: Element, params?: { direction?: 'in' | 'out', mode?: 'horizontal' | 'vertical' }) {
+/**
+ * Parses a CSS length into pixels, falling back to 0 when the value cannot be
+ * parsed. `getComputedStyle` returns the empty string for layout properties
+ * while an element is inside a `display: none` subtree, and `parseFloat('')`
+ * is `NaN` — which would otherwise end up as invalid `NaNpx` keyframes.
+ */
+function px(value: string): number {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function growTransition(node: Element, params?: {mode?: 'horizontal' | 'vertical'}) {
     const height = node.scrollHeight;
     const style = getComputedStyle(node);
-    const paddingTop = parseFloat(style.paddingTop);
-    const paddingBottom = parseFloat(style.paddingBottom);
-    const marginTop = parseFloat(style.marginTop);
-    const marginBottom = parseFloat(style.marginBottom);
-    const {direction = 'in', mode = 'vertical'} = params ?? {};
-    const easing = direction === 'in' ? gentleBackOut : cubicOut;
-    return {
-        duration: direction === 'in' ? 300 : 220,
-        easing,
-        css: (t: number) => {
-            if (mode === 'horizontal') {
-                return `
-                    overflow: hidden;
-                    opacity: ${t};
-                    width: ${Math.max(0, t * node.scrollWidth)}px;
-                    padding-left: ${Math.max(0, t * parseFloat(style.paddingLeft))}px;
-                    padding-right: ${Math.max(0, t * parseFloat(style.paddingRight))}px;
-                    margin-left: ${Math.max(0, t * parseFloat(style.marginLeft))}px;
-                    margin-right: ${Math.max(0, t * parseFloat(style.marginRight))}px;
-                    transform: translateX(${(1 - t) * -(parseFloat(style.paddingLeft) + parseFloat(style.paddingRight))}px);
-                `;
-            }
+    const {mode = 'vertical'} = params ?? {};
 
-            return `
+    if (mode === 'horizontal') {
+        const width = node.scrollWidth;
+        const paddingLeft = px(style.paddingLeft);
+        const paddingRight = px(style.paddingRight);
+        const marginLeft = px(style.marginLeft);
+        const marginRight = px(style.marginRight);
+        return {
+            duration: 300,
+            easing: gentleBackOut,
+            css: (t: number) => `
                 overflow: hidden;
                 opacity: ${t};
-                height: ${Math.max(0, t * height)}px;
-                padding-top: ${Math.max(0, t * paddingTop)}px;
-                padding-bottom: ${Math.max(0, t * paddingBottom)}px;
-                margin-top: ${Math.max(0, t * marginTop)}px;
-                margin-bottom: ${Math.max(0, t * marginBottom)}px;
-                transform: translateY(${(1 - t) * -(paddingTop + paddingBottom)}px);
-            `;
-        }
+                width: ${Math.max(0, t * width)}px;
+                padding-left: ${Math.max(0, t * paddingLeft)}px;
+                padding-right: ${Math.max(0, t * paddingRight)}px;
+                margin-left: ${Math.max(0, t * marginLeft)}px;
+                margin-right: ${Math.max(0, t * marginRight)}px;
+                transform: translateX(${(1 - t) * -(paddingLeft + paddingRight)}px);
+            `
+        };
+    }
+
+    const paddingTop = px(style.paddingTop);
+    const paddingBottom = px(style.paddingBottom);
+    const marginTop = px(style.marginTop);
+    const marginBottom = px(style.marginBottom);
+    return {
+        duration: 300,
+        easing: gentleBackOut,
+        css: (t: number) => `
+            overflow: hidden;
+            opacity: ${t};
+            height: ${Math.max(0, t * height)}px;
+            padding-top: ${Math.max(0, t * paddingTop)}px;
+            padding-bottom: ${Math.max(0, t * paddingBottom)}px;
+            margin-top: ${Math.max(0, t * marginTop)}px;
+            margin-bottom: ${Math.max(0, t * marginBottom)}px;
+            transform: translateY(${(1 - t) * -(paddingTop + paddingBottom)}px);
+        `
     };
 }


### PR DESCRIPTION
Context: Investigation started with console warnings during normal usage. Two independent fixes came out of it.

1. public/js/ai_chat_functions.js — "Response is already done. Ignoring triggerReceived call."

Why: Every completed chat message logged this warning. buildRequestObjectForAiConv() already calls response.triggerReceived() internally on all exit paths, but its caller in sendMessageConv() unconditionally called it again afterward — a guaranteed double-fire, not an edge case.

What changed:
- Removed the redundant triggerReceived() after await buildRequestObjectForAiConv(...).
- Guarded the remaining trigger calls with if (!response.done) (same pattern the group-chat code already uses), so aborting mid-stream no longer warns either.
- Bonus fix: a stream ending without a header previously returned without resolving its promise, leaving the composer stuck in "responding" forever. It now completes the response and resolves.
No behavior change otherwise; the console.warn in SendMessageResponse stays — it correctly flagged this bug.

2. resources/js/utils/transitions/growTransition.ts — "Keyframe property value 'NaNpx' is invalid"

Why: getComputedStyle() returns "" for layout properties while an element is inside a display: none subtree. parseFloat("") = NaN, which flowed into the generated keyframes. The transition is used in ~11 places (composer, header, tool chips...), so any state toggle while hidden sprayed warnings.

What changed:
- All style reads go through a small px() helper that maps unparseable values to 0.
- Removed the dead direction param — no caller ever passed it, so out-transitions always ran with the "in" easing anyway (no runtime change).
- Minor: horizontal mode now parses styles once up front instead of on every animation frame.