### PR TITLE
fix: Add 'minimal solution' for tz issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@
 #  - APP_TRUSTED_PROXIES:    Comma separated list of trusted proxy IP addresses (e.g. "10.0.1.11", or "10.0.1.11,10.0.1.12" for multiple proxies).
 #                            This is important if you are using a reverse proxy in front of HAWKI, to ensure that the application can correctly determine the client's IP address and other request information.
 #  - APP_DEBUG:              Enable debug output: "true" or "false"
-#  - APP_TIMEZONE:           Timezone of the web server
+#  - APP_TIMEZONE:           Timezone of the web server. Must be an IANA location zone (e.g. "Europe/Berlin"), not an abbreviation like "CET" (fixed offset without DST)
 #  - APP_LOCALE:             Language of the user interface
 #  - APP_FALLBACK_LOCALE:    Fallback language (for any missing translations)
 #  - APP_FAKER_LOCALE:       You shouldn't need this
@@ -49,7 +49,7 @@ APP_URL="http://127.0.0.1:8000"
 #APP_TRUSTED_PROXIES=
 APP_ENV="local"
 APP_DEBUG="false"
-APP_TIMEZONE="CET"
+APP_TIMEZONE="Europe/Berlin"
 
 APP_LOCALE="de_DE"
 APP_FALLBACK_LOCALE="en_US"

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Services\System\Http\SsrfSafeGetterMacro;
 use App\Services\System\ScheduleWithDynamicIntervalFactory;
 use App\Services\System\Time\CarbonClock;
 use App\Services\System\Time\CarbonClockInterface;
+use App\Services\System\Time\TimezoneGuard;
 use App\Services\System\UsageTypes\UsageContext;
 use App\Services\System\UserTypes\UserContext;
 use App\Services\Translation\LocaleService;
@@ -54,6 +55,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Fail loud and early when the configured timezone is an unsafe
+        // abbreviation (e.g. "CET"): PHP treats those as fixed offsets without
+        // DST in some code paths while applying DST in others, silently
+        // corrupting stored timestamps and time-window comparisons.
+        TimezoneGuard::ensureSafe((string) config('app.timezone'));
+
         $this->bootSchedulerMacros();
         $this->bootArrMacros();
         $this->bootUrlGeneratorMacros();

--- a/app/Services/System/Time/Exceptions/InvalidTimezoneException.php
+++ b/app/Services/System/Time/Exceptions/InvalidTimezoneException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\System\Time\Exceptions;
+
+/**
+ * Thrown by {@see \App\Services\System\Time\TimezoneGuard} when the configured
+ * application timezone is not a valid IANA location timezone.
+ *
+ * Timezone abbreviations such as `CET` or `EST` are interpreted as fixed
+ * offsets without DST by some components (e.g. the {@see \Symfony\Component\Clock\Clock}
+ * backing {@see \App\Services\System\Time\CarbonClock}) while Carbon/Eloquent
+ * apply DST, causing a timestamp drift that corrupts debounce windows and
+ * audit trails. This exception makes such a misconfiguration fail loud and
+ * early at boot.
+ */
+class InvalidTimezoneException extends \RuntimeException
+{
+    public static function forTimezone(string $timezone): self
+    {
+        return new self(sprintf(
+            'APP_TIMEZONE "%s" is not a valid IANA location timezone. '
+            . 'Use a zone like "Europe/Berlin" (or "UTC"); abbreviations such as "CET"/"EST" '
+            . 'are fixed offsets without DST and cause clock/Eloquent timestamp drift.',
+            $timezone,
+        ));
+    }
+}

--- a/app/Services/System/Time/TimezoneGuard.php
+++ b/app/Services/System/Time/TimezoneGuard.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\System\Time;
+
+use App\Services\System\Time\Exceptions\InvalidTimezoneException;
+
+/**
+ * Guards the application timezone against ambiguous abbreviations.
+ *
+ * A timezone is considered safe when it is an IANA location zone (which applies
+ * DST consistently across {@see \Symfony\Component\Clock\Clock}, Carbon and
+ * Eloquent), `UTC`, or an `Etc/*` fixed-offset zone. Abbreviations such as
+ * `CET`, `EST` or `GMT` are rejected because PHP treats them as fixed offsets
+ * without DST via `new DateTimeZone(...)`, while Carbon's default-timezone
+ * resolution applies DST — producing a one-hour wall-clock drift that silently
+ * corrupts debounce windows and stored timestamps.
+ */
+final class TimezoneGuard
+{
+    /**
+     * @throws InvalidTimezoneException when $timezone is not a safe IANA location timezone
+     */
+    public static function ensureSafe(string $timezone): void
+    {
+        $safe = \in_array($timezone, timezone_identifiers_list(\DateTimeZone::ALL), true)
+            || 'UTC' === $timezone
+            || str_starts_with($timezone, 'Etc/');
+
+        if (!$safe) {
+            throw InvalidTimezoneException::forTimezone($timezone);
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -74,7 +74,7 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', 'CET'),
+    'timezone' => env('APP_TIMEZONE', 'Europe/Berlin'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Unit/Services/System/Time/TimezoneGuardTest.php
+++ b/tests/Unit/Services/System/Time/TimezoneGuardTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\System\Time;
+
+use App\Services\System\Time\Exceptions\InvalidTimezoneException;
+use App\Services\System\Time\TimezoneGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+#[CoversClass(TimezoneGuard::class)]
+class TimezoneGuardTest extends TestCase
+{
+    // =========================================================================
+    // Safe timezones
+    // =========================================================================
+
+    public static function safeTimezones(): iterable
+    {
+        yield 'location zone' => ['Europe/Berlin'];
+        yield 'another location zone' => ['America/New_York'];
+        yield 'UTC literal' => ['UTC'];
+        yield 'Etc fixed offset' => ['Etc/UTC'];
+        yield 'Etc GMT offset' => ['Etc/GMT+5'];
+    }
+
+    #[DataProvider('safeTimezones')]
+    public function testItAcceptsSafeTimezone(string $timezone): void
+    {
+        TimezoneGuard::ensureSafe($timezone);
+
+        static::addToAssertionCount(1);
+    }
+
+    // =========================================================================
+    // Rejected abbreviations and invalid zones
+    // =========================================================================
+
+    public static function unsafeTimezones(): iterable
+    {
+        yield 'CET abbreviation' => ['CET'];
+        yield 'EST abbreviation' => ['EST'];
+        yield 'PST abbreviation' => ['PST'];
+        yield 'GMT abbreviation' => ['GMT'];
+        yield 'typo' => ['Europe/Berli'];
+        yield 'empty' => [''];
+    }
+
+    #[DataProvider('unsafeTimezones')]
+    public function testItRejectsUnsafeTimezone(string $timezone): void
+    {
+        static::expectException(InvalidTimezoneException::class);
+        static::expectExceptionMessage('is not a valid IANA location timezone');
+
+        TimezoneGuard::ensureSafe($timezone);
+    }
+
+    public function testItIncludesTheOffendingTimezoneInTheMessage(): void
+    {
+        try {
+            TimezoneGuard::ensureSafe('CET');
+            static::fail('Expected InvalidTimezoneException to be thrown.');
+        } catch (InvalidTimezoneException $e) {
+            static::assertStringContainsString('"CET"', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# Timezone Handling: Root Cause, Fix, and the UTC Design Option

Origin: https://github.com/hawk-digital-environments/HAWKI/pull/326#issuecomment-5251409900
---

## 1. TL;DR
- It should have been `APP_TIMEZONE=UTC` from the start
- The guard is the "minimal solution" avoiding migrations.
- `APP_TIMEZONE="CET"` (the historical default) is not a real timezone. It is an
  **abbreviation**, and PHP resolves it with **two incompatible semantics**
  depending on where it is used.
- Laravel stores datetimes as **naive wall-clock strings** (no offset). Write
  side uses the clock's timezone object; read side parses in the default
  timezone. Under `CET` those two disagree by one hour in summer.
- The first code that compared clock-time against an Eloquent round-tripped
  timestamp (assistant version debounce) therefore silently broke. The tests
  caught it first because the test wiring (UTC `MockClock`) is 'broken'
  **year-round**, while prod-CET only breaks during CEST months.
- The only local fix is to **forbid abbreviated zones** — hence
  `TimezoneGuard`. With IANA zones (e.g. `Europe/Berlin`) the existing
  read/write architecture is already fully consistent; the guard is not a
  band-aid, it removes the only input that breaks it.
- A deeper option — storing UTC — exists and is outlined in section 7. It is a
  **fundamental design shift** and must be discussed before executing.

---

## 2. Symptom

`AssistantUpdatedVersion` (feature branch) debounces assistant version rows:
merge into the latest version when it was touched within N seconds, else create
a new version. The comparison is:

```php
// app/Services/Assistant/Listeners/AssistantUpdatedVersion.php
$now = $this->clock->now();
if (null !== $latest && $now->subSeconds($seconds) <= $latest->updated_at) {
    // merge
}
```

Unit tests (`AssistantUpdatedVersionTest`) failed: every trigger created a new
version instead of merging, despite the clock advancing only seconds.

---

## 3. Root cause — three layers

### Layer 1: PHP resolves `CET` two different ways

Verified empirically on PHP 8.3.33:

```php
date_default_timezone_set('CET');

// Semantics A — default timezone (naive-string parsing):
(new DateTimeImmutable('2026-07-15 12:00:00'))->format('P'); // +02:00 (DST applied)
(new DateTimeImmutable('2026-01-15 12:00:00'))->format('P'); // +01:00

// Semantics B — explicit object (what Symfony NativeClock materializes):
$tz = new DateTimeZone('CET');
(new DateTimeImmutable('2026-07-15 12:00:00', $tz))->format('P'); // +01:00, forever
```

`DateTimeZone('CET')` is a fixed-offset zone without DST. Default-timezone
parsing of the same name applies DST. IANA location zones (`Europe/Berlin`)
resolve **identically** in both positions — only abbreviations diverge.

### Layer 2: Laravel's DB round-trip is naive

- **Write**: `Connection::prepareBindings()`
  (`vendor/.../Database/Connection.php:779`) formats the datetime via
  `$value->format(...)` — a naive wall-clock string in the *instance's*
  timezone. The offset is discarded.
- **Read**: Eloquent `asDateTime()`
  (`vendor/.../Eloquent/Concerns/HasAttributes.php:1598`) parses that naive
  string back in the **default timezone** (`date_default_timezone_set()` from
  `config('app.timezone')` via `LoadConfiguration.php:65`).

Round-trip is only exact when the write-side zone semantics and the
default-timezone semantics agree. For abbreviations they do not.

### Layer 3: The clock made the latent defect reachable

Laravel boots `date_default_timezone_set('CET')`. Before the clock
architecture existed, services used `Carbon::now()`, which resolves in the
*default* timezone — the same semantics as the read side. The round-trip was
accidentally self-consistent; `CET` was harmless.

`App\Services\System\Time\CarbonClock` (introduced in the v2.5.0 squash-merge
`ebe82c1e`, PR #304; renamed in `ce61948a`, PR #310 — rename only, no behavior
change) routes through Symfony `NativeClock`, which **materializes** the
default tz string into a `DateTimeZone` object → fixed +01:00. Write and read
sides now disagreed in summer.

Empirical drift (`clockNow − eloquentReadBack`), measured with the project's
own classes:

| Scenario | Winter | Summer |
|---|---|---|
| `Carbon::now()` write (pre-clock path) | 0 | 0 |
| `CarbonClock->now()` write, `app.timezone=Europe/Berlin` | 0 | 0 |
| `CarbonClock->now()` write, `app.timezone=CET` (prod wiring) | 0 | **+3600 s** |
| Test wiring: `MockClock` (UTC-walled) + `app.timezone=CET` | **+3600 s** | **+7200 s** |

`+3600 s` means `updated_at` reads back one hour in the past →
`$now->subSeconds(10) <= $latest->updated_at` is false → no merge. The
`MockClock` case fails year-round, which is why the bug surfaced as test
failings in winter and summer alike, while prod-CET would only misbehave
during CEST months.

---

## 4. Why the guard is the only *local* fix

"Make read and write uniformly respect offsets" is impossible while storing
wall-clock strings under an abbreviated zone: the write side can only produce
`DateTimeZone`-object wall times (fixed semantics), the read side can only
parse naive strings (DST semantics under an abbreviation default). The two
semantics disagree about the *same string*; no app-level conversion removes
that — even `setTimezone(new DateTimeZone('CET'))` before storing still
round-trips +3600 s in summer. Therefore the abbreviation itself must be
eliminated: fail loud and early at boot (`TimezoneGuard::ensureSafe`) and
default to `Europe/Berlin`.

Note that with IANA zones the architecture is already uniform (drift = 0 in
the table above), so no further read/write changes are needed once the
configuration is safe.

---

## 5. What `fix/safe-app-timezone` changes

- `app/Services/System/Time/TimezoneGuard.php` +
  `Exceptions/InvalidTimezoneException.php`: allow IANA location zones, `UTC`,
  `Etc/*`; reject everything else at boot with an explanatory message.
- `app/Providers/AppServiceProvider::boot()`: calls the guard once.
- `config/app.php` + `.env.example`: default `CET` → `Europe/Berlin`.
- `tests/Unit/Services/System/Time/TimezoneGuardTest.php`: 12 cases.

Reviewer verification:

```sh
bin/env composer test:unit                 # full suite green
bin/env composer test:stan                 # static analysis green

# Guard fires (container swallows host env vars, so inject inside PHP):
bin/env php -r 'putenv("APP_TIMEZONE=CET"); $_ENV["APP_TIMEZONE"]="CET"; $_SERVER["APP_TIMEZONE"]="CET";
require "vendor/autoload.php"; $app = require "bootstrap/app.php";
$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();'
# => InvalidTimezoneException: APP_TIMEZONE "CET" is not a valid IANA location timezone. ...

# Drift repro (independent of the guard):
bin/env php -r 'require "vendor/autoload.php"; date_default_timezone_set("CET");
$n = (new App\Services\System\Time\CarbonClock())->now();
$b = Carbon\CarbonImmutable::createFromFormat("!Y-m-d H:i:s", $n->format("Y-m-d H:i:s"));
echo "drift=", $n->getTimestamp() - $b->getTimestamp(), "s\n";'   # 3600 in summer
```

Deploy note: machines with a stale `APP_TIMEZONE="CET"` in `.env` will fail
boot until updated — that is the intended fail-loud behavior; announce it.

---

## 6. Residual limitation (accepted)

Wall-clock storage in a DST zone (`Europe/Berlin`) is self-consistent for
instants, but local wall time is **ambiguous during the fall-back hour** and
nonexistent during spring-forward — twice a year, ordering by naive strings
within that hour is ill-defined. This is inherent to local-time storage and
the reason the UTC option below exists.

---

## 7. Option B — `APP_TIMEZONE=UTC`: fundamental design shift (discuss before executing)

**Not part of this branch.** Benefits: canonical storage, immune to any
server-tz misconfiguration and to DST-transition ambiguity (section 6).
Uniform by construction (UTC write wall = UTC parse).

Verified preconditions that make it feasible here:

- API edge is already offset-aware: `Model::serializeDate()` emits ISO-8601
  with offset (`vendor/.../HasAttributes.php:1649`), so API clients receive
  absolute instants regardless of storage tz.
- Scheduler (`routes/console.php`) currently uses interval-based entries only
  (`everyFifteenMinutes()`), which are tz-independent; per-event
  `->timezone('Europe/Berlin')` exists if clock-bound schedules
  (`dailyAt(...)` via `ScheduleWithDynamicIntervalFactory`) are ever added.
- Clock consumers use epoch timestamps / cache TTLs — unaffected.

Migration implications (must be planned, not improvised):

1. **Data migration**: existing rows are Berlin wall time (assumption to
   validate: all deployments ran CET or Europe/Berlin). One-time
   `CONVERT_TZ(col, 'Europe/Berlin', 'UTC')` per datetime column; ~5 migration
   files contain `timestamp` columns (audit `database/migrations` fully before
   executing — including plain `dateTime`/`date` columns). SQLite test DBs are
   in-memory and unaffected.
2. **Ambiguous fall-back hour rows** cannot be converted unambiguously —
   decide an interpretation rule (e.g. always pre-transition offset).
3. **Log/schedule/display semantics**: `app.timezone` drives log timestamps
   and default schedule interpretation; pin expectations explicitly.
4. **Rollout order**: deploy guard first (this branch), then pin scheduler
   timezones, then flip env + migrate data inside a maintenance window; keep a
   rollback path (reverse `CONVERT_TZ`).

Decision checklist before executing: confirm no external consumer parses
naive datetime strings from the DB directly; confirm frontend never renders
server wall time without offset; agree on the fall-back-hour rule.

---

## 8. History

| Commit | Effect |
|---|---|
| (long-standing) | `APP_TIMEZONE="CET"` default — latent, harmless while all time came from the default tz |
| `ebe82c1e` (PR #304, v2.5.0) | Clock architecture introduced; `CET` becomes *exploitable*; consumers are TTL-only → still no symptom |
| `ce61948a` (PR #310) | Rename `Clock` → `CarbonClock` + interface + docs table; **no behavior change** |
| `242af898` (feature branch) | Debounce listener = first clock-vs-Eloquent comparison → symptom; guard + `Europe/Berlin` + `phpunit.xml` UTC pin added in the same commit |
| `fix/safe-app-timezone` | Isolate guard changes for review |
